### PR TITLE
Fix panic when all arguments are dropped from the new version of a funnction

### DIFF
--- a/cmd/compare.go
+++ b/cmd/compare.go
@@ -115,6 +115,11 @@ func compare(provider string, oldCommit string, newCommit string) error {
 		}
 
 		for propName, prop := range f.Inputs.Properties {
+			if newFunc.Inputs == nil {
+				violations = append(violations, fmt.Sprintf("Function %q missing input %q", funcName, propName))
+				continue
+			}
+
 			newProp, ok := newFunc.Inputs.Properties[propName]
 			if !ok {
 				violations = append(violations, fmt.Sprintf("Function %q missing input %q", funcName, propName))

--- a/pkg/stats_test.go
+++ b/pkg/stats_test.go
@@ -202,6 +202,37 @@ func TestCountStats_InternalRefs_Outputs(t *testing.T) {
 	assert.Equal(t, 3, stats.Resources.TotalOutputProperties)
 }
 
+func TestCountStats_NoInputs(t *testing.T) {
+	testSchema := schema.PackageSpec{
+		Functions: map[string]schema.FunctionSpec{
+			"test:index/getFooNoInputs:getFooNoInputs": {
+				Description: "This is a function that has no inputs, like getGlobalClient on the auth0 provider.",
+				Outputs: &schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"output1": {
+							Description: "0123456789",
+						},
+					},
+				},
+			},
+		},
+		Resources: map[string]schema.ResourceSpec{
+			"test:index/noInputs:noInputs": {
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Description: "This is a resource that has no inputs. Not known whether this case exists in the wild, but it sure shouldn't panic if we hit it!",
+					Properties: map[string]schema.PropertySpec{
+						"output1": {
+							Description: "0123456789",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_ = CountStats(testSchema)
+}
+
 func TestCountStats_ExternalRef(t *testing.T) {
 	testSchema := schema.PackageSpec{
 		Resources: map[string]schema.ResourceSpec{


### PR DESCRIPTION
To test:

```bash
go build && ./schema-tools compare -p auth0 -n afaf824a9890
```

Will panic on `master`, will not panic on this branch.