### PR TITLE
Check that a new func schema has outputs != nil

### DIFF
--- a/cmd/compare.go
+++ b/cmd/compare.go
@@ -130,6 +130,11 @@ func compare(provider string, oldCommit string, newCommit string) error {
 
 		if f.Outputs != nil {
 			for propName, prop := range f.Outputs.Properties {
+				if newFunc.Outputs == nil {
+					violations = append(violations, fmt.Sprintf("Function %q missing output %q", funcName, propName))
+					continue
+				}
+
 				newProp, ok := newFunc.Outputs.Properties[propName]
 				if !ok {
 					violations = append(violations, fmt.Sprintf("Function %q missing output %q", funcName, propName))


### PR DESCRIPTION
A prior change (#20) added a check that the field `.Outputs` on the old schema is not nil, when comparing with a new schema. This suggests it's possible for the outputs on the _new_ func schema to be nil, so check for that too. This avoids a possible nil pointer access (`newFunc.Outputs.Properties`), and gives an accurate violation message.
