### PR TITLE
Disregard default versions when squeezing

### DIFF
--- a/cmd/squeeze.go
+++ b/cmd/squeeze.go
@@ -79,7 +79,7 @@ func compareGroup(path, groupName string) error {
 
 	resVersions := codegen.StringSet{}
 	for name := range sch.Resources {
-		if !strings.Contains(name, "/") {
+		if !pkg.IsVersionedName(name) {
 			continue
 		}
 		if groupName == pkg.VersionlessName(name) {
@@ -109,6 +109,10 @@ func compareAll(path, out string) error {
 
 	resourceMap := map[string]codegen.StringSet{}
 	for name := range sch.Resources {
+		if !pkg.IsVersionedName(name) {
+			continue
+		}
+
 		vls := pkg.VersionlessName(name)
 		if existing, ok := resourceMap[vls]; ok {
 			existing.Add(name)

--- a/pkg/stats.go
+++ b/pkg/stats.go
@@ -200,6 +200,7 @@ func CountStats(sch schema.PackageSpec) PulumiSchemaStats {
 	return stats
 }
 
+// "azure-native:appplatform/v20230101preview" -> "appplatform"
 func VersionlessName(name string) string {
 	parts := strings.Split(name, ":")
 	mod := parts[1]
@@ -208,4 +209,9 @@ func VersionlessName(name string) string {
 		mod = modParts[0]
 	}
 	return fmt.Sprintf("%s:%s", mod, parts[2])
+}
+
+// Is it of the form "azure-native:appplatform/v20230101preview" or just "azure-native:appplatform"?
+func IsVersionedName(name string) bool {
+	return strings.Contains(name, "/v")
 }


### PR DESCRIPTION
Otherwise, if version v1 is default for resource R, we'll output that R_v1 is compatible with R, which is the same version. For instance, the current squeeze result has
```
"azure-native:attestation/v20201001:PrivateEndpointConnection": "azure-native:attestation:PrivateEndpointConnection"
```
but according to v1-spec.yaml, the tracking version of `attestation` is 2020-10-01, so this line is just saying that `v20201001:PrivateEndpointConnection` is compatible with itself.