### PR TITLE
Add a --details flag to the stats command

### DIFF
--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -3,18 +3,20 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/schema-tools/pkg"
 	"github.com/spf13/cobra"
 )
 
 func statsCmd() *cobra.Command {
 	var provider string
+	var details bool
 
 	command := &cobra.Command{
 		Use:   "stats",
 		Short: "Get the stats of a current schema",
 		RunE: func(command *cobra.Command, args []string) error {
-			return stats(provider)
+			return stats(provider, details)
 		},
 	}
 
@@ -22,10 +24,13 @@ func statsCmd() *cobra.Command {
 		"the provider whose schema we should analyze")
 	_ = command.MarkFlagRequired("provider")
 
+	command.Flags().BoolVarP(&details, "details", "d", false,
+		"show the details with a list of all resources and functions")
+
 	return command
 }
 
-func stats(provider string) error {
+func stats(provider string, details bool) error {
 	schemaUrl := fmt.Sprintf("https://raw.githubusercontent.com/pulumi/pulumi-%s/master/provider/cmd/pulumi-resource-%[1]s/schema.json", provider)
 	sch, err := pkg.DownloadSchema(schemaUrl)
 	if err != nil {
@@ -38,6 +43,17 @@ func stats(provider string) error {
 	statsBytes, _ := json.MarshalIndent(schemaStats, "", "  ")
 	statsString := string(statsBytes)
 	fmt.Printf(statsString)
+
+	if details {
+		fmt.Printf("\n\n### All Resources:\n\n")
+		for _, n := range codegen.SortedKeys(sch.Resources) {
+			fmt.Println(n)
+		}
+		fmt.Printf("\n### All Functions:\n\n")
+		for _, n := range codegen.SortedKeys(sch.Functions) {
+			fmt.Println(n)
+		}
+	}
 
 	return nil
 }


### PR DESCRIPTION
Adds a `details` flag to the `stats` command to show a full list of resources and functions in a package.

Fix #31 

```
$ schema-tools stats -p tls -d   
Provider: tls
{
  "Functions": {
    "TotalFunctions": 2,
    "TotalDescriptionBytes": 4132,
    "TotalInputPropertyDescriptionBytes": 842,
    "InputPropertiesMissingDescriptions": 0,
    "TotalOutputPropertyDescriptionBytes": 0,
    "OutputPropertiesMissingDescriptions": 0
  },
  "Resources": {
    "TotalResources": 4,
    "TotalDescriptionBytes": 2987,
    "TotalInputProperties": 45,
    "InputPropertiesMissingDescriptions": 0,
    "TotalOutputProperties": 64,
    "OutputPropertiesMissingDescriptions": 0
  }
}

### All Resources:

tls:index/certRequest:CertRequest
tls:index/locallySignedCert:LocallySignedCert
tls:index/privateKey:PrivateKey
tls:index/selfSignedCert:SelfSignedCert

### All Functions:

tls:index/getCertificate:getCertificate
tls:index/getPublicKey:getPublicKey
```