### PR TITLE
Catch changes in required

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
       - main
       - master
 env:
-  GO_VERSION: '1.18.x'
+  GO_VERSION: '1.20.x'
 
 jobs:
   ci:
@@ -21,5 +21,7 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{env.GO_VERSION}}
-      - name: Run Go Build
-        run: go build main.go
+      - name: Build
+        run: make build
+      - name: Test
+        run: make test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,10 @@ jobs:
         uses: actions/checkout@v2
       - name: Unshallow clone
         run: git fetch --prune --unshallow --tags
-      - name: Install Go 1.18
+      - name: Install Go 1.20
         uses: actions/setup-go@v2
         with:
-          go-version: '1.18.x'
+          go-version: '1.20.x'
       - name: Goreleaser publish
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/cmd/compare.go
+++ b/cmd/compare.go
@@ -217,9 +217,9 @@ func breakingChanges(oldSchema, newSchema schema.PackageSpec) []string {
 		// Since we don't know if this type will be consumed by pulumi (as an
 		// input) or by the user (as an output), this inherits the strictness of
 		// both inputs and outputs.
-		newRequred := newSetFromList(newTyp.Required)
+		newRequired := newSetFromList(newTyp.Required)
 		for _, r := range typ.Required {
-			if !newRequred.Has(r) {
+			if !newRequired.Has(r) {
 				violation("missing required property %q", r)
 			}
 		}

--- a/cmd/compare.go
+++ b/cmd/compare.go
@@ -120,14 +120,14 @@ func breakingChanges(oldSchema, newSchema schema.PackageSpec) []string {
 			violations = append(violations, vs...)
 		}
 
-		oldRequiredInputs := setFromList(res.RequiredInputs)
+		oldRequiredInputs := setFromSlice(res.RequiredInputs)
 		for _, input := range newRes.RequiredInputs {
 			if !oldRequiredInputs.Has(input) {
 				violation(changedToRequired("input", input))
 			}
 		}
 
-		newRequiredProperties := setFromList(newRes.Required)
+		newRequiredProperties := setFromSlice(newRes.Required)
 		for _, prop := range res.Required {
 			if !newRequiredProperties.Has(prop) {
 				violation(changedToOptional("property", prop))
@@ -163,7 +163,7 @@ func breakingChanges(oldSchema, newSchema schema.PackageSpec) []string {
 			}
 
 			if newFunc.Inputs != nil {
-				oldRequired := setFromList(f.Inputs.Required)
+				oldRequired := setFromSlice(f.Inputs.Required)
 				for _, req := range newFunc.Inputs.Required {
 					if !oldRequired.Has(req) {
 						violation(changedToRequired("input", req))
@@ -191,7 +191,7 @@ func breakingChanges(oldSchema, newSchema schema.PackageSpec) []string {
 
 			var newRequired set[string]
 			if newFunc.Outputs != nil {
-				newRequired = setFromList(newFunc.Outputs.Required)
+				newRequired = setFromSlice(newFunc.Outputs.Required)
 			}
 			for _, req := range f.Outputs.Required {
 				if !newRequired.Has(req) {
@@ -225,13 +225,13 @@ func breakingChanges(oldSchema, newSchema schema.PackageSpec) []string {
 		// Since we don't know if this type will be consumed by pulumi (as an
 		// input) or by the user (as an output), this inherits the strictness of
 		// both inputs and outputs.
-		newRequired := setFromList(newTyp.Required)
+		newRequired := setFromSlice(newTyp.Required)
 		for _, r := range typ.Required {
 			if !newRequired.Has(r) {
 				violation(changedToOptional("property", r))
 			}
 		}
-		required := setFromList(typ.Required)
+		required := setFromSlice(typ.Required)
 		for _, r := range newTyp.Required {
 			if !required.Has(r) {
 				violation(changedToRequired("property", r))
@@ -333,9 +333,9 @@ func formatName(provider, s string) string {
 
 type set[T comparable] struct{ m map[T]struct{} }
 
-func setFromList[T comparable](elems []T) set[T] {
-	m := make(map[T]struct{}, len(elems))
-	for _, v := range elems {
+func setFromSlice[T comparable](slice []T) set[T] {
+	m := make(map[T]struct{}, len(slice))
+	for _, v := range slice {
 		m[v] = struct{}{}
 	}
 

--- a/cmd/compare_test.go
+++ b/cmd/compare_test.go
@@ -1,0 +1,185 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBreakingResourceRequired(t *testing.T) {
+	tests := []breakingTestCase{
+		{}, // No required => no breaking
+
+		{ // No change => no breaking
+			OldRequired: []string{"value"},
+			NewRequired: []string{"value"},
+		},
+		{ // Making an output optional is breaking
+			OldRequired:    []string{"value"},
+			ExpectedOutput: []string{`Resource "my-pkg:index:MyResource" missing required output "value"`},
+		},
+		{ // Making an output required is not breaking
+			NewRequired: []string{"value"},
+		},
+		{ // But making an input required is breaking
+			NewRequiredInputs: []string{"list"},
+			ExpectedOutput: []string{
+				`Resource "my-pkg:index:MyResource" added new required input "list"`,
+			},
+		},
+		{ // Making an input optional is not breaking
+			OldRequiredInputs: []string{"list"},
+		},
+	}
+
+	testBreakingRequired(t, tests, func(required, requiredInputs []string) schema.PackageSpec {
+		props := map[string]schema.PropertySpec{
+			"value": {TypeSpec: schema.TypeSpec{Type: "string"}},
+			"list": {TypeSpec: schema.TypeSpec{
+				Type:  "array",
+				Items: &schema.TypeSpec{Type: "number"},
+			}},
+		}
+		r := schema.ResourceSpec{
+			ObjectTypeSpec: schema.ObjectTypeSpec{
+				Properties: props,
+				Required:   required,
+			},
+			InputProperties: props,
+			RequiredInputs:  requiredInputs,
+		}
+		return simpleResourceSchema(r)
+	})
+}
+
+func TestBreakingFunctionRequired(t *testing.T) {
+	tests := []breakingTestCase{
+		{}, // No required => no breaking
+
+		{ // No change => no breaking
+			OldRequired: []string{"value"},
+			NewRequired: []string{"value"},
+		},
+		{ // Making an output optional is breaking
+			OldRequired:    []string{"value"},
+			ExpectedOutput: []string{`Function "my-pkg:index:MyFunction" missing required output "value"`},
+		},
+		{ // Making an output required is not breaking
+			NewRequired: []string{"value"},
+		},
+		{ // But making an input required is breaking
+			OldRequiredInputs: []string{},
+			NewRequiredInputs: []string{"list"},
+			ExpectedOutput: []string{
+				`Function "my-pkg:index:MyFunction" added new required input "list"`,
+			},
+		},
+		{ // Making an input optional is not breaking
+			OldRequiredInputs: []string{"list"},
+		},
+	}
+
+	testBreakingRequired(t, tests, func(required, requiredInputs []string) schema.PackageSpec {
+		f := schema.FunctionSpec{}
+		if required != nil {
+			f.Outputs = &schema.ObjectTypeSpec{
+				Required: required,
+			}
+		}
+		if requiredInputs != nil {
+			f.Inputs = &schema.ObjectTypeSpec{
+				Required: requiredInputs,
+			}
+		}
+		return simpleFunctionSchema(f)
+	})
+}
+
+func TestBreakingTypeRequired(t *testing.T) {
+	tests := []breakingTestCase{
+		{}, // No required => no breaking
+
+		{ // No change => no breaking
+			OldRequired: []string{"value"},
+			NewRequired: []string{"value"},
+		},
+		{ // Adding a requirement is breaking
+			OldRequired: []string{"value"},
+			NewRequired: []string{"value", "list"},
+			ExpectedOutput: []string{
+				`Type "my-pkg:index:MyResource" added new required property "list"`,
+			},
+		},
+		{ // Removing a requirement is breaking
+			OldRequired: []string{"value", "list"},
+			NewRequired: []string{"value"},
+			ExpectedOutput: []string{
+				`Type "my-pkg:index:MyResource" missing required property "list"`,
+			},
+		},
+	}
+
+	testBreakingRequired(t, tests, func(required, _ []string) schema.PackageSpec {
+		t := schema.ComplexTypeSpec{
+			ObjectTypeSpec: schema.ObjectTypeSpec{
+				Required: required,
+			},
+		}
+		return simpleTypeSchema(t)
+	})
+}
+
+type breakingTestCase struct {
+	OldRequired       []string
+	OldRequiredInputs []string
+	NewRequired       []string
+	NewRequiredInputs []string
+	ExpectedOutput    []string
+}
+
+func testBreakingRequired(
+	t *testing.T, tests []breakingTestCase,
+	newT func(required, requiredInput []string) schema.PackageSpec,
+) {
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			old := newT(tt.OldRequired, tt.OldRequiredInputs)
+			new := newT(tt.NewRequired, tt.NewRequiredInputs)
+
+			violations := breakingChanges(old, new)
+
+			assert.Equal(t, tt.ExpectedOutput, violations)
+		})
+	}
+}
+
+func simpleEmptySchema() schema.PackageSpec {
+	return schema.PackageSpec{
+		Name:    "my-pkg",
+		Version: "v1.2.3",
+	}
+}
+
+func simpleResourceSchema(r schema.ResourceSpec) schema.PackageSpec {
+	p := simpleEmptySchema()
+	p.Resources = map[string]schema.ResourceSpec{
+		p.Name + ":index:MyResource": r,
+	}
+	return p
+}
+
+func simpleFunctionSchema(f schema.FunctionSpec) schema.PackageSpec {
+	p := simpleEmptySchema()
+	p.Functions = map[string]schema.FunctionSpec{
+		p.Name + ":index:MyFunction": f,
+	}
+	return p
+}
+func simpleTypeSchema(t schema.ComplexTypeSpec) schema.PackageSpec {
+	p := simpleEmptySchema()
+	p.Types = map[string]schema.ComplexTypeSpec{
+		p.Name + ":index:MyResource": t,
+	}
+	return p
+}

--- a/cmd/compare_test.go
+++ b/cmd/compare_test.go
@@ -17,7 +17,7 @@ func TestBreakingResourceRequired(t *testing.T) {
 		},
 		{ // Making an output optional is breaking
 			OldRequired:    []string{"value"},
-			ExpectedOutput: []string{`Resource "my-pkg:index:MyResource" missing required output "value"`},
+			ExpectedOutput: []string{`Resource "my-pkg:index:MyResource" property "value" is no longer Required`},
 		},
 		{ // Making an output required is not breaking
 			NewRequired: []string{"value"},
@@ -25,7 +25,7 @@ func TestBreakingResourceRequired(t *testing.T) {
 		{ // But making an input required is breaking
 			NewRequiredInputs: []string{"list"},
 			ExpectedOutput: []string{
-				`Resource "my-pkg:index:MyResource" added new required input "list"`,
+				`Resource "my-pkg:index:MyResource" input "list" has changed to Required`,
 			},
 		},
 		{ // Making an input optional is not breaking
@@ -63,7 +63,7 @@ func TestBreakingFunctionRequired(t *testing.T) {
 		},
 		{ // Making an output optional is breaking
 			OldRequired:    []string{"value"},
-			ExpectedOutput: []string{`Function "my-pkg:index:MyFunction" missing required output "value"`},
+			ExpectedOutput: []string{`Function "my-pkg:index:MyFunction" property "value" is no longer Required`},
 		},
 		{ // Making an output required is not breaking
 			NewRequired: []string{"value"},
@@ -72,7 +72,7 @@ func TestBreakingFunctionRequired(t *testing.T) {
 			OldRequiredInputs: []string{},
 			NewRequiredInputs: []string{"list"},
 			ExpectedOutput: []string{
-				`Function "my-pkg:index:MyFunction" added new required input "list"`,
+				`Function "my-pkg:index:MyFunction" input "list" has changed to Required`,
 			},
 		},
 		{ // Making an input optional is not breaking
@@ -108,14 +108,14 @@ func TestBreakingTypeRequired(t *testing.T) {
 			OldRequired: []string{"value"},
 			NewRequired: []string{"value", "list"},
 			ExpectedOutput: []string{
-				`Type "my-pkg:index:MyResource" added new required property "list"`,
+				`Type "my-pkg:index:MyResource" property "list" has changed to Required`,
 			},
 		},
 		{ // Removing a requirement is breaking
 			OldRequired: []string{"value", "list"},
 			NewRequired: []string{"value"},
 			ExpectedOutput: []string{
-				`Type "my-pkg:index:MyResource" missing required property "list"`,
+				`Type "my-pkg:index:MyResource" property "list" is no longer Required`,
 			},
 		},
 	}


### PR DESCRIPTION
Fixes #33 

If an input is newly marked as required, that is a breaking change.

If an output is newly marked as optional, that is a breaking change.

If a type field is newly marked as required or optional, that is a breaking change.

This PR notes these breaking changes.