### PR TITLE
Add rich text output

### DIFF
--- a/internal/cmd/compare.go
+++ b/internal/cmd/compare.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/schema-tools/internal/pkg"
@@ -272,7 +273,8 @@ func compareSchemas(out io.Writer, provider string, oldSchema, newSchema schema.
 		fmt.Fprintf(out, "Found %d breaking changes:\n", lenViolations)
 	}
 
-	out.Write(displayedViolations.Bytes())
+	_, err := out.Write(displayedViolations.Bytes())
+	contract.AssertNoErrorf(err, "writing to a bytes.Buffer failing indicates OOM")
 
 	var newResources, newFunctions []string
 	for resName := range newSchema.Resources {

--- a/internal/cmd/compare_test.go
+++ b/internal/cmd/compare_test.go
@@ -210,7 +210,7 @@ func testBreakingRequired(
 			tt.ExpectedOutput.Display(expected, 10_000)
 			violations.Display(actual, 10_000)
 
-			assert.Equal(t, string(expected.Bytes()), string(actual.Bytes()))
+			assert.Equal(t, expected.String(), actual.String())
 		})
 	}
 }

--- a/internal/cmd/compare_test.go
+++ b/internal/cmd/compare_test.go
@@ -22,7 +22,7 @@ func TestBreakingResourceRequired(t *testing.T) {
 			ExpectedOutput: expectedRes(func(n *diagtree.Node) {
 				n.Label("required").Value("value").
 					SetDescription(diagtree.Info, "property is no longer Required")
-			}), // []string{`Resource "my-pkg:index:MyResource" property "value" is no longer Required`},
+			}),
 		},
 		{ // Making an output required is not breaking
 			NewRequired: []string{"value"},

--- a/internal/cmd/compare_test.go
+++ b/internal/cmd/compare_test.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/schema-tools/internal/util/diagtree"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -16,17 +18,21 @@ func TestBreakingResourceRequired(t *testing.T) {
 			NewRequired: []string{"value"},
 		},
 		{ // Making an output optional is breaking
-			OldRequired:    []string{"value"},
-			ExpectedOutput: []string{`Resource "my-pkg:index:MyResource" property "value" is no longer Required`},
+			OldRequired: []string{"value"},
+			ExpectedOutput: expectedRes(func(n *diagtree.Node) {
+				n.Label("required").Value("value").
+					SetDescription(diagtree.Info, "property is no longer Required")
+			}), // []string{`Resource "my-pkg:index:MyResource" property "value" is no longer Required`},
 		},
 		{ // Making an output required is not breaking
 			NewRequired: []string{"value"},
 		},
 		{ // But making an input required is breaking
 			NewRequiredInputs: []string{"list"},
-			ExpectedOutput: []string{
-				`Resource "my-pkg:index:MyResource" input "list" has changed to Required`,
-			},
+			ExpectedOutput: expectedRes(func(n *diagtree.Node) {
+				n.Label("required inputs").Value("list").
+					SetDescription(diagtree.Info, "input has changed to Required")
+			}),
 		},
 		{ // Making an input optional is not breaking
 			OldRequiredInputs: []string{"list"},
@@ -64,10 +70,11 @@ func TestRemovedProperty(t *testing.T) {
 	old.Properties["field1"] = schema.PropertySpec{TypeSpec: schema.TypeSpec{Type: "string"}}
 	oldSchema := simpleResourceSchema(old)
 	newSchema := simpleResourceSchema(simpleResource(nil, nil))
-	changes := breakingChanges(oldSchema, newSchema)
-	assert.Equal(t, []string{
-		"Resource \"my-pkg:index:MyResource\" missing output \"field1\"",
-	}, changes)
+	changes := *breakingChanges(oldSchema, newSchema)
+	assert.Equal(t, expectedRes(func(n *diagtree.Node) {
+		n.Label("properties").Value("field1").
+			SetDescription(diagtree.Warn, `missing output "field1"`)
+	}), changes)
 
 }
 
@@ -80,8 +87,11 @@ func TestBreakingFunctionRequired(t *testing.T) {
 			NewRequired: []string{"value"},
 		},
 		{ // Making an output optional is breaking
-			OldRequired:    []string{"value"},
-			ExpectedOutput: []string{`Function "my-pkg:index:MyFunction" property "value" is no longer Required`},
+			OldRequired: []string{"value"},
+			ExpectedOutput: expectedFunc(func(n *diagtree.Node) {
+				n.Label("outputs").Label("required").Value("value").SetDescription(diagtree.Info,
+					"property is no longer Required")
+			}),
 		},
 		{ // Making an output required is not breaking
 			NewRequired: []string{"value"},
@@ -89,9 +99,10 @@ func TestBreakingFunctionRequired(t *testing.T) {
 		{ // But making an input required is breaking
 			OldRequiredInputs: []string{},
 			NewRequiredInputs: []string{"list"},
-			ExpectedOutput: []string{
-				`Function "my-pkg:index:MyFunction" input "list" has changed to Required`,
-			},
+			ExpectedOutput: expectedFunc(func(n *diagtree.Node) {
+				n.Label("inputs").Label("required").Value("list").SetDescription(diagtree.Info,
+					"input has changed to Required")
+			}),
 		},
 		{ // Making an input optional is not breaking
 			OldRequiredInputs: []string{"list"},
@@ -129,16 +140,18 @@ func TestBreakingTypeRequired(t *testing.T) {
 		{ // Adding a requirement is breaking
 			OldRequired: []string{"value"},
 			NewRequired: []string{"value", "list"},
-			ExpectedOutput: []string{
-				`Type "my-pkg:index:MyResource" property "list" has changed to Required`,
-			},
+			ExpectedOutput: expectedTyp(func(n *diagtree.Node) {
+				n.Label("required").Value("list").SetDescription(diagtree.Info,
+					"property has changed to Required")
+			}),
 		},
 		{ // Removing a requirement is breaking
 			OldRequired: []string{"value", "list"},
 			NewRequired: []string{"value"},
-			ExpectedOutput: []string{
-				`Type "my-pkg:index:MyResource" property "list" is no longer Required`,
-			},
+			ExpectedOutput: expectedTyp(func(n *diagtree.Node) {
+				n.Label("required").Value("list").SetDescription(diagtree.Info,
+					"property is no longer Required")
+			}),
 		},
 	}
 
@@ -155,12 +168,30 @@ func TestBreakingTypeRequired(t *testing.T) {
 	})
 }
 
+func expectedFunc(f func(*diagtree.Node)) diagtree.Node {
+	expected := new(diagtree.Node)
+	f(expected.Label("Functions").Value("my-pkg:index:MyFunction"))
+	return *expected
+}
+
+func expectedRes(f func(*diagtree.Node)) diagtree.Node {
+	expected := new(diagtree.Node)
+	f(expected.Label("Resources").Value("my-pkg:index:MyResource"))
+	return *expected
+}
+
+func expectedTyp(f func(*diagtree.Node)) diagtree.Node {
+	expected := new(diagtree.Node)
+	f(expected.Label("Types").Value("my-pkg:index:MyType"))
+	return *expected
+}
+
 type breakingTestCase struct {
 	OldRequired       []string
 	OldRequiredInputs []string
 	NewRequired       []string
 	NewRequiredInputs []string
-	ExpectedOutput    []string
+	ExpectedOutput    diagtree.Node
 }
 
 func testBreakingRequired(
@@ -169,12 +200,17 @@ func testBreakingRequired(
 ) {
 	for _, tt := range tests {
 		t.Run("", func(t *testing.T) {
-			old := newT(tt.OldRequired, tt.OldRequiredInputs)
-			new := newT(tt.NewRequired, tt.NewRequiredInputs)
+			oldSchema := newT(tt.OldRequired, tt.OldRequiredInputs)
+			newSchema := newT(tt.NewRequired, tt.NewRequiredInputs)
 
-			violations := breakingChanges(old, new)
+			violations := breakingChanges(oldSchema, newSchema)
 
-			assert.Equal(t, tt.ExpectedOutput, violations)
+			expected, actual := new(bytes.Buffer), new(bytes.Buffer)
+
+			tt.ExpectedOutput.Display(expected, 10_000)
+			violations.Display(actual, 10_000)
+
+			assert.Equal(t, string(expected.Bytes()), string(actual.Bytes()))
 		})
 	}
 }
@@ -204,7 +240,7 @@ func simpleFunctionSchema(f schema.FunctionSpec) schema.PackageSpec {
 func simpleTypeSchema(t schema.ComplexTypeSpec) schema.PackageSpec {
 	p := simpleEmptySchema()
 	p.Types = map[string]schema.ComplexTypeSpec{
-		p.Name + ":index:MyResource": t,
+		p.Name + ":index:MyType": t,
 	}
 	return p
 }

--- a/internal/util/diagtree/diagtree.go
+++ b/internal/util/diagtree/diagtree.go
@@ -75,6 +75,10 @@ func (m *Node) Display(out io.Writer, max int) int {
 }
 
 func (m *Node) display(out io.Writer, level int, prefix bool, max int) int {
+	write := func(s string) {
+		_, err := out.Write([]byte(s))
+		contract.AssertNoErrorf(err, "failed to write display")
+	}
 	if m == nil || !m.doDisplay || max <= 0 {
 		// Nothing to display
 		return 0
@@ -92,12 +96,12 @@ func (m *Node) display(out io.Writer, level int, prefix bool, max int) int {
 			display += " " + m.Description
 		}
 
-		out.Write([]byte(display))
+		write(display)
 	}
 
 	if level > 1 && m.Severity == None {
 		if s := m.uniqueSuccessor(); s != nil {
-			out.Write([]byte(": "))
+			write(": ")
 			return s.display(out, level, false, max-displayed) + displayed
 		}
 	}
@@ -117,9 +121,9 @@ func (m *Node) display(out io.Writer, level int, prefix bool, max int) int {
 	for _, i := range order {
 		if m.subfields[i].doDisplay && !didEndLine {
 			if level > 1 {
-				out.Write([]byte(":\n"))
+				write(":\n")
 			} else {
-				out.Write([]byte("\n"))
+				write("\n")
 			}
 			didEndLine = true
 		}
@@ -128,7 +132,7 @@ func (m *Node) display(out io.Writer, level int, prefix bool, max int) int {
 	}
 
 	if !didEndLine {
-		out.Write([]byte("\n"))
+		write("\n")
 	}
 
 	return displayed

--- a/internal/util/diagtree/diagtree.go
+++ b/internal/util/diagtree/diagtree.go
@@ -88,7 +88,12 @@ func (m *Node) display(out io.Writer, level int, prefix bool, max int) int {
 	var display string
 	if m.Title != "" {
 		if prefix {
-			display = m.levelPrefix(level) + m.severity()
+			display = m.levelPrefix(level)
+			// levels 0 & 1 are always top level, so we special case them
+			// here.
+			if level > 1 || m.Severity != None {
+				display += m.severity()
+			}
 		}
 		display += m.Title
 		if m.Description != "" {

--- a/internal/util/diagtree/diagtree.go
+++ b/internal/util/diagtree/diagtree.go
@@ -1,0 +1,152 @@
+package diagtree
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+)
+
+type Node struct {
+	Title       string
+	Description string
+	Severity    Severity
+	Subfields   []*Node
+
+	doDisplay bool
+	parent    *Node
+}
+
+func (m *Node) subfield(name string) *Node {
+	contract.Assertf(name != "", "we cannot display an empty name")
+	for _, v := range m.Subfields {
+		if v.Title == name {
+			return v
+		}
+	}
+	v := &Node{
+		Title:  name,
+		parent: m,
+	}
+	m.Subfields = append(m.Subfields, v)
+	return v
+}
+
+func (m *Node) Label(name string) *Node {
+	return m.subfield(name)
+}
+
+func (m *Node) Value(value string) *Node {
+	return m.subfield(fmt.Sprintf("%q", value))
+}
+
+func (m *Node) levelPrefix(level int) string {
+	switch level {
+	case 0:
+		return "###"
+	case 1:
+		return "####"
+	}
+	if level < 0 {
+		return ""
+	}
+	return strings.Repeat("  ", (level-2)*2) + "-"
+}
+
+func (m *Node) Display(out io.Writer, max int) int {
+	return m.display(out, 0, true, max)
+}
+
+func (m *Node) display(out io.Writer, level int, prefix bool, max int) int {
+	if m == nil || !m.doDisplay || max <= 0 {
+		// Nothing to display
+		return 0
+	}
+
+	var displayed int
+	var display string
+	if m.Title != "" {
+		if prefix {
+			display = fmt.Sprintf("%s %s ",
+				m.levelPrefix(level),
+				m.severity())
+		}
+		display += m.Title + ": "
+		if m.Description != "" {
+			displayed += 1
+			display += m.Description
+		}
+
+		out.Write([]byte(display))
+	}
+
+	if level > 1 && m.Severity == None {
+		if s := m.uniqueSuccessor(); s != nil {
+			return s.display(out, level, false, max-displayed) + displayed
+		}
+	}
+
+	out.Write([]byte{'\n'})
+
+	order := make([]int, len(m.Subfields))
+	for i := range order {
+		order[i] = i
+	}
+	if level > 0 {
+		// Obtain an ordering on the subfields without mutating `.Subfields`.
+		sort.Slice(order, func(i, j int) bool {
+			return m.Subfields[order[i]].Title < m.Subfields[order[j]].Title
+		})
+	}
+
+	for _, f := range order {
+		n := m.Subfields[f].display(out, level+1, true, max-displayed)
+		displayed += n
+	}
+	return displayed
+}
+
+func (m *Node) uniqueSuccessor() *Node {
+	var us *Node
+	for _, s := range m.Subfields {
+		if !s.doDisplay {
+			continue
+		}
+		if us != nil {
+			return nil
+		}
+		us = s
+	}
+	return us
+}
+
+func (m *Node) severity() Severity {
+	for m != nil {
+		s := m.uniqueSuccessor()
+		if s == nil {
+			return m.Severity
+		}
+		m = s
+	}
+	return None
+}
+
+type Severity string
+
+const (
+	None   Severity = ""
+	Info   Severity = "`🟢`"
+	Warn   Severity = "`🟡`"
+	Danger Severity = "`🔴`"
+)
+
+func (m *Node) SetDescription(level Severity, msg string, a ...any) {
+	for v := m.parent; v != nil && !v.doDisplay; v = v.parent {
+		v.doDisplay = true
+	}
+	m.doDisplay = true
+	m.Description = fmt.Sprintf(msg, a...)
+	m.Severity = level
+}

--- a/internal/util/diagtree/diagtree_test.go
+++ b/internal/util/diagtree/diagtree_test.go
@@ -1,0 +1,89 @@
+package diagtree_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/pulumi/schema-tools/internal/util/diagtree"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrunedDisplay(t *testing.T) {
+	t.Parallel()
+	n := func(f func(*diagtree.Node)) *diagtree.Node {
+		n := &diagtree.Node{Title: "Top Level"}
+		f(n)
+		n.Prune()
+		return n
+	}
+	nn := func(f func(*diagtree.Node)) *diagtree.Node {
+		return n(func(n *diagtree.Node) {
+			f(n.Label("l1").Label("l2"))
+		})
+	}
+
+	tests := []testCase{
+		{
+			input: n(func(n *diagtree.Node) {
+				n.SetDescription(diagtree.Info, "A top level value")
+			}),
+			expected:      "### `🟢` Top Level A top level value\n",
+			maxItems:      10,
+			expectedCount: 1,
+		},
+		{
+			input: nn(func(n *diagtree.Node) {
+				n = n.Label("l3")
+				n.SetDescription(diagtree.Info, "A nested value")
+			}),
+			expected:      "### Top Level\n#### l1\n- `🟢` l2: l3 A nested value\n",
+			maxItems:      10,
+			expectedCount: 1,
+		},
+		{
+			input: nn(func(n *diagtree.Node) {
+				n.SetDescription(diagtree.Info, "nested descriptions")
+				n.Label("value1").SetDescription(diagtree.Warn, "warn")
+				n.Label("value2").SetDescription(diagtree.Danger, "danger")
+			}),
+			expected:      "### Top Level\n#### l1\n- `🟢` l2 nested descriptions:\n    - `🟡` value1 warn\n    - `🔴` value2 danger\n",
+			maxItems:      10,
+			expectedCount: 3,
+		},
+		{
+			input: nn(func(n *diagtree.Node) {
+				n.Label("no data").Value("still nothing")
+				bt := n.Label("branching tree")
+				bt.Label("empty branch")
+				bt.Value("has description").SetDescription(diagtree.Info, "a description")
+				n.Label("another top level branch")
+			}),
+			expected:      "### Top Level\n#### l1\n- `🟢` l2: branching tree: \"has description\" a description\n",
+			maxItems:      10,
+			expectedCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run("", func(t *testing.T) {
+			t.Parallel()
+			tt.check(t)
+		})
+	}
+}
+
+type testCase struct {
+	input *diagtree.Node
+
+	expected      string
+	expectedCount int
+	maxItems      int
+}
+
+func (tt testCase) check(t *testing.T) {
+	actual := new(bytes.Buffer)
+	actualCount := tt.input.Display(actual, tt.maxItems)
+	assert.Equal(t, tt.expectedCount, actualCount)
+	assert.Equal(t, tt.expected, actual.String())
+}


### PR DESCRIPTION
Fixes #38 

Important features include:
- Output is sorted lexicographically, so the result is now deterministic.
- Single nesting are folded together, so:
  ```
    - a
      - b
        - `🔴` c
  ```
  is rendered as
  ```
  - `🔴` a: b: c
  ```
- There are 3 levels of "Severity" for a breaking change.
  - Changes in the required-ness of a field are `🟢`.
  - Changes in the type or existence of a property are `🟡`.
  - Removing a resource, type or function is `🔴`.

An example of the new output:
```
### Does the PR have any schema changes?

Found 9 breaking changes:

#### Types
- `🟢` "cloudflare:index/{name}:RulesetRuleActionParametersBrowserTtl": required: "mode" property is no longer Required
- `🟢` "cloudflare:index/{name}:RulesetRuleActionParametersEdgeTtl": required: "mode" property is no longer Required
- `🟢` "cloudflare:index/{name}:RulesetRuleActionParametersEdgeTtlStatusCodeTtl": required: "value" property is no longer Required
- "cloudflare:index/{name}:RulesetRuleActionParametersFromList": required:
    - `🟢` "key" property is no longer Required
    - `🟢` "name" property is no longer Required
- `🟡` "cloudflare:index/{name}:RulesetRuleActionParametersOverrides": properties: "status" missing
- `🟡` "cloudflare:index/{name}:RulesetRuleActionParametersOverridesCategory": properties: "status" missing
- `🟡` "cloudflare:index/{name}:RulesetRuleActionParametersOverridesRule": properties: "status" missing
- `🟡` "cloudflare:index/{name}:RulesetRuleLogging": properties: "status" missing

#### New resources:

- `index/addressMap.AddressMap`
- `index/deviceDexTest.DeviceDexTest`
- `index/listItem.ListItem`
- `index/regionalHostname.RegionalHostname`
- `index/turnstileWidget.TurnstileWidget`
- `index/workerDomain.WorkerDomain`

#### New functions:

- `index/getList.getList`
- `index/getLists.getLists`
```

GitHub renders that as:
---
### Does the PR have any schema changes?

Found 9 breaking changes:

#### Types
- `🟢` "cloudflare:index/{name}:RulesetRuleActionParametersBrowserTtl": required: "mode" property is no longer Required
- `🟢` "cloudflare:index/{name}:RulesetRuleActionParametersEdgeTtl": required: "mode" property is no longer Required
- `🟢` "cloudflare:index/{name}:RulesetRuleActionParametersEdgeTtlStatusCodeTtl": required: "value" property is no longer Required
- "cloudflare:index/{name}:RulesetRuleActionParametersFromList": required:
    - `🟢` "key" property is no longer Required
    - `🟢` "name" property is no longer Required
- `🟡` "cloudflare:index/{name}:RulesetRuleActionParametersOverrides": properties: "status" missing
- `🟡` "cloudflare:index/{name}:RulesetRuleActionParametersOverridesCategory": properties: "status" missing
- `🟡` "cloudflare:index/{name}:RulesetRuleActionParametersOverridesRule": properties: "status" missing
- `🟡` "cloudflare:index/{name}:RulesetRuleLogging": properties: "status" missing

#### New resources:

- `index/addressMap.AddressMap`
- `index/deviceDexTest.DeviceDexTest`
- `index/listItem.ListItem`
- `index/regionalHostname.RegionalHostname`
- `index/turnstileWidget.TurnstileWidget`
- `index/workerDomain.WorkerDomain`

#### New functions:

- `index/getList.getList`
- `index/getLists.getLists`
---