### PR TITLE
Fix breaking changes count

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,14 @@
-VERSION=$(shell git describe --tags)
+VERSION:=$(shell git describe --tags)
+LDFLAGS=-ldflags="-X github.com/pulumi/schema-tools/version.Version=$(VERSION)"
 
 test:
 	go test ./...
 
 build:
-	go build \
-		-ldflags="-X github.com/pulumi/schema-tools/version.Version=$(VERSION)"
+	go build $(LDFLAGS)
 
 lint:
 	golangci-lint run
+
+install:
+	go install $(LDFLAGS)

--- a/internal/util/diagtree/diagtree.go
+++ b/internal/util/diagtree/diagtree.go
@@ -71,18 +71,19 @@ func (m *Node) levelPrefix(level int) string {
 }
 
 type cappedWriter struct {
-	max int
-	out io.Writer
+	// The number of remaining writes before we hit the cap.
+	remaining int
+	out       io.Writer
 }
 
 func (c *cappedWriter) incr() {
-	if c.max > 0 {
-		c.max--
+	if c.remaining > 0 {
+		c.remaining--
 	}
 }
 
 func (c *cappedWriter) Write(p []byte) (n int, err error) {
-	if c.max > 0 {
+	if c.remaining > 0 {
 		return c.out.Write(p)
 	}
 	// We pretend we finished the write, but we do nothing.


### PR DESCRIPTION
We previously related the number of breaking changes with the number of breaking changes printed (which was capped at 500). This meant that we would never detect more than 500 breaking changes. By abstracting the printing mechanism to understand its own capacity, we get an accurate count of the number of conflicts without increasing code complexity in the display mechanism.