### PR TITLE
Support local schemas for `stats`

### DIFF
--- a/internal/cmd/stats.go
+++ b/internal/cmd/stats.go
@@ -16,7 +16,6 @@ func statsCmd() *cobra.Command {
 	var provider, repository, tag string
 	var details bool
 
-
 	command := &cobra.Command{
 		Use:   "stats",
 		Short: "Get the stats of a current schema",
@@ -50,7 +49,6 @@ func stats(provider string, repositoryUrl string, details bool, tag string) erro
 
 	schemaStats := pkg.CountStats(sch)
 
-	fmt.Printf("Provider: %s\n", provider)
 	statsBytes, _ := json.MarshalIndent(schemaStats, "", "  ")
 	_, err = os.Stdout.Write(statsBytes)
 	if err != nil {

--- a/internal/pkg/util.go
+++ b/internal/pkg/util.go
@@ -7,33 +7,35 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"strings"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 )
 
 func DownloadSchema(ctx context.Context, repositoryUrl string,
 	provider string, commit string) (schema.PackageSpec, error) {
-	baseSource, err := func() (GitSource, error) {
-		// Support schematised URLS if the URL has a "schema" part we recognize
-		url, err := url.Parse(repositoryUrl)
-		if err != nil {
-			return nil, err
-		}
-
-		switch url.Scheme {
-		case "github":
-			return newGithubSource(url, provider)
-		case "gitlab":
-			return newGitlabSource(url, provider)
-		default:
-			return nil, fmt.Errorf("unknown schema source scheme: %s", url.Scheme)
-		}
-	}()
+	var gitSource GitSource
+	// Support schematised URLS if the URL has a "schema" part we recognize
+	url, err := url.Parse(repositoryUrl)
 	if err != nil {
 		return schema.PackageSpec{}, err
 	}
 
-	resp, _, err := baseSource.Download(ctx, commit, getHTTPResponse)
+	switch url.Scheme {
+	case "file":
+		return LoadLocalPackageSpec(strings.TrimPrefix(repositoryUrl, "file:"))
+	case "github":
+		gitSource, err = newGithubSource(url, provider)
+	case "gitlab":
+		gitSource, err = newGitlabSource(url, provider)
+	default:
+		return schema.PackageSpec{}, fmt.Errorf("unknown schema source scheme: %s", url.Scheme)
+	}
+	if err != nil {
+		return schema.PackageSpec{}, err
+	}
+
+	resp, _, err := gitSource.Download(ctx, commit, getHTTPResponse)
 	if err != nil {
 		return schema.PackageSpec{}, err
 	}


### PR DESCRIPTION
Aggregating data is much easier to iterate on when you can cache files locally. This makes it easy to analyze local files.

This is part of https://github.com/pulumi/pulumi-terraform-bridge/issues/1662.