### PR TITLE
Add category summary and input/output type usage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21
 require (
 	github.com/deckarep/golang-set/v2 v2.5.0
 	github.com/h2non/gock v1.2.0
+	github.com/pulumi/inflector v0.2.1
 	github.com/pulumi/pulumi/pkg/v3 v3.115.2
 	github.com/pulumi/pulumi/sdk/v3 v3.115.2
 	github.com/spf13/cobra v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -164,6 +164,8 @@ github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231 h1:vkHw5I/plNdTr435
 github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231/go.mod h1:murToZ2N9hNJzewjHBgfFdXhZKjY3z5cYC1VXk+lbFE=
 github.com/pulumi/esc v0.6.2 h1:+z+l8cuwIauLSwXQS0uoI3rqB+YG4SzsZYtHfNoXBvw=
 github.com/pulumi/esc v0.6.2/go.mod h1:jNnYNjzsOgVTjCp0LL24NsCk8ZJxq4IoLQdCT0X7l8k=
+github.com/pulumi/inflector v0.2.1 h1:bqyiish3tq//vLeLiEstSFE5K7RNjy/ce47ed4QATu8=
+github.com/pulumi/inflector v0.2.1/go.mod h1:HUFCjcPTz96YtTuUlwG3i3EZG4WlniBvR9bd+iJxCUY=
 github.com/pulumi/pulumi/pkg/v3 v3.115.2 h1:lMpGc/pSAsSz4ZE4IRi1/XYWzyZQpjy0OJ4TNcMIr+k=
 github.com/pulumi/pulumi/pkg/v3 v3.115.2/go.mod h1:Sbl1hEyTXpc1Yu2GbKU6h3rWyuUkrTAzTZ+MioYOZl8=
 github.com/pulumi/pulumi/sdk/v3 v3.115.2 h1:CFx/KfS3fsp2EiXnX70JNUBvHADNqiQ617AVslu5I6E=


### PR DESCRIPTION
## Summary
- add explicit diff categories for breaking-change types
- compute per-category counts and include a summary section in compare output
- classify type changes and optional/required changes by input vs output usage

## Rationale / Impact
Schema diffs are currently a flat list; reviewers have to infer patterns. This adds a stable, machine-readable categorization and a concise summary so reviewers can quickly assess scope and risk. It also makes input/output usage explicit, which avoids over-reporting (e.g., output-only type changes counted as input breaking changes).

## Sample Output
```
### Does the PR have any schema changes?

Summary by category:
missing-resource: 1
type-changed-output: 4
optional-to-required-input: 2
```

## Notes
- Designed as the base for follow-on compare improvements.
- No schema comparison semantics change beyond categorization and reporting.