### PR TITLE
Add --ignore-categories for compare

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,12 @@ Type "docker:index/ServiceTaskSpecResourcesLimitsGenericResources:ServiceTaskSpe
 - `index/getRemoteImage.getRemoteImage`
 ```
 
+To ignore specific categories and get per-category totals:
+
+```shell
+$ schema-tools compare -p snowflake -o v1.0.0 -n v1.1.0 --ignore-categories type-changed-output,optional-to-required-output
+```
+
 ## Squeeze
 
 To show the backwards-incompatible changes between two versioned resources:


### PR DESCRIPTION
## Summary
- add `--ignore-categories` to omit selected diff categories from output and counts
- validate category names and surface a helpful list of valid values
- document usage in the README

## Rationale / Impact
Reviewers often want to focus on specific classes of schema changes (e.g., ignore output-only differences or known churn). This flag makes the compare output filterable without altering schema analysis.

## Sample Output
```
$ schema-tools compare -p snowflake -o v1.0.0 -n v1.1.0 \
  --ignore-categories type-changed-output,optional-to-required-output

Summary by category:
missing-resource: 1
type-changed-input: 2
```

## Notes
- Depends on PR #78 (category summary + input/output usage).
- Filtering affects both the summary counts and the displayed diff nodes.