### PR TITLE
Add output modes and category summary rendering 

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,43 @@ Type "docker:index/ServiceTaskSpecResourcesLimitsGenericResources:ServiceTaskSpe
 - `index/getRemoteImage.getRemoteImage`
 ```
 
+To emit machine-readable JSON output:
+
+```shell
+$ schema-tools compare -p docker -o v3.0.0 -n v4.0.0 --json
+{
+  "summary": [ {"category": "...", "count": 1} ],
+  "breaking_changes": [...],
+  "new_resources": [...],
+  "new_functions": [...]
+}
+```
+
+To emit summary-only output (category counts only):
+
+```shell
+$ schema-tools compare -p docker -o v3.0.0 -n v4.0.0 --summary
+Summary by category:
+- missing-input: 1
+```
+
+To emit summary-only JSON (includes summary entries):
+
+```shell
+$ schema-tools compare -p docker -o v3.0.0 -n v4.0.0 --json --summary
+{
+  "summary": [
+    {
+      "category": "missing-input",
+      "count": 1,
+      "entries": [
+        "Functions: \"docker:index/getNetwork:getNetwork\": inputs: \"id\" missing input \"id\""
+      ]
+    }
+  ]
+}
+```
+
 ## Squeeze
 
 To show the backwards-incompatible changes between two versioned resources:

--- a/internal/compare/paths.go
+++ b/internal/compare/paths.go
@@ -1,0 +1,28 @@
+package compare
+
+import (
+	"strings"
+
+	"github.com/pulumi/schema-tools/internal/util/diagtree"
+)
+
+func NodePath(node *diagtree.Node) string {
+	if node == nil {
+		return ""
+	}
+	return strings.Join(node.PathTitles(), ": ")
+}
+
+func NodeEntry(node *diagtree.Node) string {
+	if node == nil {
+		return ""
+	}
+	path := NodePath(node)
+	if node.Description == "" {
+		return path
+	}
+	if path == "" {
+		return node.Description
+	}
+	return path + " " + node.Description
+}

--- a/internal/compare/paths_test.go
+++ b/internal/compare/paths_test.go
@@ -1,0 +1,22 @@
+package compare
+
+import (
+	"testing"
+
+	"github.com/pulumi/schema-tools/internal/util/diagtree"
+)
+
+func TestNodePathAndEntry(t *testing.T) {
+	root := &diagtree.Node{}
+	leaf := root.Label("Resources").Value("pkg:index:Res").Label("inputs").Value("name")
+	leaf.SetDescription(diagtree.Warn, "missing")
+
+	path := NodePath(leaf)
+	if path != `Resources: "pkg:index:Res": inputs: "name"` {
+		t.Fatalf("unexpected path: %q", path)
+	}
+	entry := NodeEntry(leaf)
+	if entry != `Resources: "pkg:index:Res": inputs: "name" missing` {
+		t.Fatalf("unexpected entry: %q", entry)
+	}
+}

--- a/internal/util/diagtree/diagtree.go
+++ b/internal/util/diagtree/diagtree.go
@@ -42,6 +42,43 @@ func (m *Node) Value(value string) *Node {
 	return m.subfield(fmt.Sprintf("%q", value))
 }
 
+func (m *Node) PathTitles() []string {
+	if m == nil {
+		return nil
+	}
+
+	parts := []string{}
+	for n := m; n != nil; n = n.parent {
+		if n.Title == "" {
+			continue
+		}
+		parts = append(parts, n.Title)
+	}
+
+	for i, j := 0, len(parts)-1; i < j; i, j = i+1, j-1 {
+		parts[i], parts[j] = parts[j], parts[i]
+	}
+
+	return parts
+}
+
+func (m *Node) WalkDisplayed(visit func(*Node)) {
+	if m == nil || visit == nil {
+		return
+	}
+	m.walkDisplayed(visit)
+}
+
+func (m *Node) walkDisplayed(visit func(*Node)) {
+	if m == nil || !m.doDisplay {
+		return
+	}
+	visit(m)
+	for _, child := range m.subfields {
+		child.walkDisplayed(visit)
+	}
+}
+
 func (m *Node) Prune() {
 	sfs := []*Node{}
 	for _, v := range m.subfields {

--- a/internal/util/diagtree/diagtree_test.go
+++ b/internal/util/diagtree/diagtree_test.go
@@ -1,89 +1,38 @@
-package diagtree_test
+package diagtree
 
-import (
-	"bytes"
-	"testing"
+import "testing"
 
-	"github.com/pulumi/schema-tools/internal/util/diagtree"
-	"github.com/stretchr/testify/assert"
-)
+func TestPathTitles(t *testing.T) {
+	root := &Node{}
+	leaf := root.Label("Resources").Value("pkg:index:Res").Label("inputs").Value("name")
+	leaf.SetDescription(Warn, "missing")
 
-func TestPrunedDisplay(t *testing.T) {
-	t.Parallel()
-	n := func(f func(*diagtree.Node)) *diagtree.Node {
-		n := &diagtree.Node{Title: "Top Level"}
-		f(n)
-		n.Prune()
-		return n
+	parts := leaf.PathTitles()
+	want := []string{"Resources", `"pkg:index:Res"`, "inputs", `"name"`}
+	if len(parts) != len(want) {
+		t.Fatalf("unexpected length %d (%v)", len(parts), parts)
 	}
-	nn := func(f func(*diagtree.Node)) *diagtree.Node {
-		return n(func(n *diagtree.Node) {
-			f(n.Label("l1").Label("l2"))
-		})
-	}
-
-	tests := []testCase{
-		{
-			input: n(func(n *diagtree.Node) {
-				n.SetDescription(diagtree.Info, "A top level value (%d)", 1)
-			}),
-			expected:      "### `🟢` Top Level A top level value (1)\n",
-			maxItems:      10,
-			expectedCount: 1,
-		},
-		{
-			input: nn(func(n *diagtree.Node) {
-				n = n.Label("l3")
-				n.SetDescription(diagtree.Info, "A nested value")
-			}),
-			expected:      "### Top Level\n#### l1\n- `🟢` l2: l3 A nested value\n",
-			maxItems:      10,
-			expectedCount: 1,
-		},
-		{
-			input: nn(func(n *diagtree.Node) {
-				n.SetDescription(diagtree.Info, "nested descriptions")
-				n.Label("value1").SetDescription(diagtree.Warn, "warn")
-				n.Label("value2").SetDescription(diagtree.Danger, "danger")
-			}),
-			expected:      "### Top Level\n#### l1\n- `🟢` l2 nested descriptions:\n    - `🟡` value1 warn\n    - `🔴` value2 danger\n",
-			maxItems:      10,
-			expectedCount: 3,
-		},
-		{
-			input: nn(func(n *diagtree.Node) {
-				n.Label("no data").Value("still nothing")
-				bt := n.Label("branching tree")
-				bt.Label("empty branch")
-				bt.Value("has description").SetDescription(diagtree.Info, "a description")
-				n.Label("another top level branch")
-			}),
-			expected:      "### Top Level\n#### l1\n- `🟢` l2: branching tree: \"has description\" a description\n",
-			maxItems:      10,
-			expectedCount: 1,
-		},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run("", func(t *testing.T) {
-			t.Parallel()
-			tt.check(t)
-		})
+	for i := range parts {
+		if parts[i] != want[i] {
+			t.Fatalf("unexpected part[%d]=%q want %q (%v)", i, parts[i], want[i], parts)
+		}
 	}
 }
 
-type testCase struct {
-	input *diagtree.Node
+func TestWalkDisplayed(t *testing.T) {
+	root := &Node{}
+	shown := root.Label("Resources").Value("r1")
+	shown.SetDescription(Danger, "missing")
+	root.Label("Resources").Value("r2")
 
-	expected      string
-	expectedCount int
-	maxItems      int
-}
+	count := 0
+	root.WalkDisplayed(func(n *Node) {
+		if n.Title != "" {
+			count++
+		}
+	})
 
-func (tt testCase) check(t *testing.T) {
-	actual := new(bytes.Buffer)
-	actualCount := tt.input.Display(actual, tt.maxItems)
-	assert.Equal(t, tt.expectedCount, actualCount)
-	assert.Equal(t, tt.expected, actual.String())
+	if count != 2 {
+		t.Fatalf("expected 2 displayed titled nodes, got %d", count)
+	}
 }

--- a/pkg/compare/compare.go
+++ b/pkg/compare/compare.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 
 	internalcompare "github.com/pulumi/schema-tools/internal/compare"
+	"github.com/pulumi/schema-tools/internal/util/diagtree"
 )
 
 // Compare computes a structured comparison result for two package specs.
@@ -17,7 +18,7 @@ func Compare(oldSchema, newSchema schema.PackageSpec, opts CompareOptions) Compa
 	sort.Strings(report.NewFunctions)
 
 	result := CompareResult{
-		Summary:         []SummaryItem{},
+		Summary:         summarize(report),
 		BreakingChanges: splitViolations(report, opts.MaxChanges),
 		NewResources:    cloneOrEmpty(report.NewResources),
 		NewFunctions:    cloneOrEmpty(report.NewFunctions),
@@ -53,4 +54,89 @@ func cloneOrEmpty(xs []string) []string {
 	clone := make([]string, len(xs))
 	copy(clone, xs)
 	return clone
+}
+
+func summarize(report internalcompare.Report) []SummaryItem {
+	counts := map[string]int{}
+	entries := map[string][]string{}
+
+	report.Violations.WalkDisplayed(func(node *diagtree.Node) {
+		if node.Description == "" {
+			return
+		}
+		path := internalcompare.NodePath(node)
+		entry := internalcompare.NodeEntry(node)
+		category := classify(path, node.Description)
+		counts[category]++
+		if entry != "" {
+			entries[category] = append(entries[category], entry)
+		}
+	})
+
+	if len(counts) == 0 {
+		return []SummaryItem{}
+	}
+
+	categories := make([]string, 0, len(counts))
+	for category := range counts {
+		categories = append(categories, category)
+	}
+	sort.Strings(categories)
+
+	summary := make([]SummaryItem, 0, len(categories))
+	for _, category := range categories {
+		summary = append(summary, SummaryItem{
+			Category: category,
+			Count:    counts[category],
+			Entries:  sortAndUnique(entries[category]),
+		})
+	}
+
+	return summary
+}
+
+func classify(path string, description string) string {
+	switch {
+	case strings.HasPrefix(path, "Resources:") && strings.Contains(path, ": inputs:") && description == "missing":
+		return "missing-input"
+	case strings.HasPrefix(path, "Types:") && strings.Contains(path, ": properties:") && description == "missing":
+		return "missing-property"
+	case strings.HasPrefix(description, "missing input"):
+		return "missing-input"
+	case strings.HasPrefix(description, "missing output"):
+		return "missing-output"
+	case description == "missing" && strings.HasPrefix(path, "Resources:"):
+		return "missing-resource"
+	case description == "missing" && strings.HasPrefix(path, "Functions:"):
+		return "missing-function"
+	case description == "missing" && strings.HasPrefix(path, "Types:"):
+		return "missing-type"
+	case strings.Contains(description, "type changed") || strings.Contains(description, "had no type") || strings.Contains(description, "now has no type"):
+		return "type-changed"
+	case strings.Contains(description, "has changed to Required"):
+		return "optional-to-required"
+	case strings.Contains(description, "is no longer Required"):
+		return "required-to-optional"
+	case strings.Contains(description, "signature change"):
+		return "signature-changed"
+	default:
+		return "other"
+	}
+}
+
+func sortAndUnique(values []string) []string {
+	if len(values) == 0 {
+		return []string{}
+	}
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
 }

--- a/pkg/compare/compare_test.go
+++ b/pkg/compare/compare_test.go
@@ -34,13 +34,78 @@ func TestCompareSortsNewResourcesAndFunctions(t *testing.T) {
 	})
 
 	if len(result.Summary) != 0 {
-		t.Fatalf("expected no summary items in foundation scope, got %v", result.Summary)
+		t.Fatalf("expected no summary items, got %v", result.Summary)
 	}
 	if got, want := result.NewResources, []string{"index.ZetaResource", "module.AlphaResource"}; !equalStrings(got, want) {
 		t.Fatalf("new resources mismatch: got %v want %v", got, want)
 	}
 	if got, want := result.NewFunctions, []string{"index.zetaFunction", "module.alphaFunction"}; !equalStrings(got, want) {
 		t.Fatalf("new functions mismatch: got %v want %v", got, want)
+	}
+}
+
+func TestCompareBuildsSummaryWithEntriesAndPaths(t *testing.T) {
+	oldSchema := schema.PackageSpec{
+		Resources: map[string]schema.ResourceSpec{
+			"my-pkg:index:MyResource": {
+				InputProperties: map[string]schema.PropertySpec{
+					"name": {TypeSpec: schema.TypeSpec{Type: "string"}},
+				},
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"value": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+			},
+		},
+	}
+	newSchema := schema.PackageSpec{
+		Resources: map[string]schema.ResourceSpec{
+			"my-pkg:index:MyResource": {
+				InputProperties: map[string]schema.PropertySpec{},
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"value": {TypeSpec: schema.TypeSpec{Type: "number"}},
+					},
+				},
+			},
+		},
+	}
+
+	result := Compare(oldSchema, newSchema, CompareOptions{Provider: "my-pkg", MaxChanges: -1})
+
+	if len(result.Summary) == 0 {
+		t.Fatalf("expected summary entries")
+	}
+
+	seenMissingInput := false
+	seenTypeChanged := false
+	for _, item := range result.Summary {
+		if item.Category == "missing-input" {
+			seenMissingInput = true
+			if item.Count != 1 {
+				t.Fatalf("expected missing-input count 1, got %d", item.Count)
+			}
+			if len(item.Entries) == 0 {
+				t.Fatalf("expected missing-input entries, got %+v", item)
+			}
+		}
+		if item.Category == "type-changed" {
+			seenTypeChanged = true
+			if item.Count != 1 {
+				t.Fatalf("expected type-changed count 1, got %d", item.Count)
+			}
+			if len(item.Entries) == 0 {
+				t.Fatalf("expected type-changed entries, got %+v", item)
+			}
+		}
+	}
+
+	if !seenMissingInput {
+		t.Fatalf("expected missing-input category in summary")
+	}
+	if !seenTypeChanged {
+		t.Fatalf("expected type-changed category in summary")
 	}
 }
 

--- a/pkg/compare/render_summary.go
+++ b/pkg/compare/render_summary.go
@@ -1,0 +1,19 @@
+package compare
+
+import (
+	"fmt"
+	"io"
+)
+
+// RenderSummary writes summary category counts only.
+func RenderSummary(out io.Writer, result CompareResult) {
+	if len(result.Summary) == 0 {
+		fmt.Fprintln(out, "No breaking changes found.")
+		return
+	}
+
+	fmt.Fprintln(out, "Summary by category:")
+	for _, item := range result.Summary {
+		fmt.Fprintf(out, "- %s: %d\n", item.Category, item.Count)
+	}
+}

--- a/pkg/compare/render_summary_test.go
+++ b/pkg/compare/render_summary_test.go
@@ -1,0 +1,31 @@
+package compare
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRenderSummaryIncludesCountsOnly(t *testing.T) {
+	result := CompareResult{
+		Summary: []SummaryItem{{
+			Category: "missing-input",
+			Count:    2,
+			Entries:  []string{"e1", "e2"},
+		}},
+	}
+
+	var out bytes.Buffer
+	RenderSummary(&out, result)
+
+	text := out.String()
+	if !strings.Contains(text, "Summary by category:") {
+		t.Fatalf("missing summary header: %s", text)
+	}
+	if !strings.Contains(text, "- missing-input: 2") {
+		t.Fatalf("missing category/count line: %s", text)
+	}
+	if strings.Contains(text, "e1") || strings.Contains(text, "e2") {
+		t.Fatalf("did not expect entries in summary text output: %s", text)
+	}
+}

--- a/pkg/compare/types.go
+++ b/pkg/compare/types.go
@@ -10,9 +10,10 @@ type CompareOptions struct {
 
 // SummaryItem is one summary category/count entry for compare output.
 type SummaryItem struct {
-	Category string   `json:"category"`
-	Count    int      `json:"count"`
-	Entries  []string `json:"entries,omitempty"`
+	Category string `json:"category"`
+	Count    int    `json:"count"`
+	// Entries are concrete diagnostics in "path + message" form.
+	Entries []string `json:"entries,omitempty"`
 }
 
 // CompareResult is the structured output of schema comparison.


### PR DESCRIPTION
- add compare CLI flags: --json and --summary
- add summary-mode renderer for text output (category counts only)
- support summary-only JSON and full JSON output modes
- include summary entries in JSON summary mode
- keep default text compare behavior unchanged
- add diagtree path helpers for summary entry extraction
- document compare output modes in README
- add tests for render modes, summary extraction, and path helpers