### PR TITLE
test(compare): comprehensive tests for compare API and renderers

### DIFF
--- a/internal/cmd/compare_test.go
+++ b/internal/cmd/compare_test.go
@@ -2,6 +2,10 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
@@ -53,6 +57,88 @@ func TestRenderCompareOutputModes(t *testing.T) {
 		assert.Contains(t, out.String(), `"summary": [`)
 		assert.NotContains(t, out.String(), `"line-1"`)
 		assert.NotContains(t, out.String(), `"r1"`)
+	})
+}
+
+func TestCompareSchemasFixtureTextOutput(t *testing.T) {
+	oldSchema, newSchema := mustLoadFixtureSchemas(t)
+
+	var out bytes.Buffer
+	compareSchemas(&out, "my-pkg", oldSchema, newSchema, -1)
+
+	text := out.String()
+	assert.Contains(t, text, "Found 8 breaking changes:")
+	assert.Contains(t, text, `"my-pkg:index:RemovedResource" missing`)
+	assert.Contains(t, text, `"my-pkg:index:removedFunction" missing`)
+	assert.Contains(t, text, `type changed from "string" to "integer"`)
+	assert.Contains(t, text, `input has changed to Required`)
+	assert.Contains(t, text, `property is no longer Required`)
+}
+
+func TestRenderCompareOutputFixtureJSON(t *testing.T) {
+	oldSchema, newSchema := mustLoadFixtureSchemas(t)
+	result := comparepkg.Compare(oldSchema, newSchema, comparepkg.CompareOptions{
+		Provider:   "my-pkg",
+		MaxChanges: -1,
+	})
+
+	t.Run("full", func(t *testing.T) {
+		var out bytes.Buffer
+		err := renderCompareOutput(&out, result, true, false)
+		assert.NoError(t, err)
+
+		var payload struct {
+			Summary []struct {
+				Category string `json:"category"`
+				Count    int    `json:"count"`
+				Entries  []string
+			} `json:"summary"`
+			BreakingChanges []string `json:"breaking_changes"`
+			NewResources    []string `json:"new_resources"`
+			NewFunctions    []string `json:"new_functions"`
+		}
+		assert.NoError(t, json.Unmarshal(out.Bytes(), &payload))
+
+		gotCounts := map[string]int{}
+		for _, item := range payload.Summary {
+			gotCounts[item.Category] = item.Count
+			assert.Empty(t, item.Entries)
+		}
+		assert.True(t, reflect.DeepEqual(gotCounts, map[string]int{
+			"missing-function":     1,
+			"missing-resource":     1,
+			"optional-to-required": 3,
+			"required-to-optional": 2,
+			"type-changed":         1,
+		}))
+		assert.Equal(t, result.BreakingChanges, payload.BreakingChanges)
+		assert.Empty(t, payload.NewResources)
+		assert.Empty(t, payload.NewFunctions)
+	})
+
+	t.Run("summary", func(t *testing.T) {
+		var out bytes.Buffer
+		err := renderCompareOutput(&out, result, true, true)
+		assert.NoError(t, err)
+
+		var payload struct {
+			Summary []struct {
+				Category string   `json:"category"`
+				Count    int      `json:"count"`
+				Entries  []string `json:"entries"`
+			} `json:"summary"`
+		}
+		assert.NoError(t, json.Unmarshal(out.Bytes(), &payload))
+
+		entriesByCategory := map[string][]string{}
+		for _, item := range payload.Summary {
+			entriesByCategory[item.Category] = item.Entries
+		}
+		assert.Equal(t, []string{
+			`Functions: "my-pkg:index:MyFunction": inputs: required: "arg" input has changed to Required`,
+			`Resources: "my-pkg:index:MyResource": required inputs: "count" input has changed to Required`,
+			`Types: "my-pkg:index:MyType": required: "count" property has changed to Required`,
+		}, entriesByCategory["optional-to-required"])
 	})
 }
 
@@ -290,4 +376,26 @@ func simpleTypeSchema(t schema.ComplexTypeSpec) schema.PackageSpec {
 		p.Name + ":index:MyType": t,
 	}
 	return p
+}
+
+func mustLoadFixtureSchemas(t testing.TB) (schema.PackageSpec, schema.PackageSpec) {
+	t.Helper()
+	oldSchema := mustReadFixtureSchema(t, "schema-old.json")
+	newSchema := mustReadFixtureSchema(t, "schema-new.json")
+	return oldSchema, newSchema
+}
+
+func mustReadFixtureSchema(t testing.TB, name string) schema.PackageSpec {
+	t.Helper()
+	path := filepath.Join("..", "..", "testdata", "compare", name)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", path, err)
+	}
+
+	var spec schema.PackageSpec
+	if err := json.Unmarshal(data, &spec); err != nil {
+		t.Fatalf("failed to unmarshal fixture %q: %v", name, err)
+	}
+	return spec
 }

--- a/pkg/compare/compare_test.go
+++ b/pkg/compare/compare_test.go
@@ -1,6 +1,12 @@
 package compare
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
@@ -45,67 +51,96 @@ func TestCompareSortsNewResourcesAndFunctions(t *testing.T) {
 }
 
 func TestCompareBuildsSummaryWithEntriesAndPaths(t *testing.T) {
-	oldSchema := schema.PackageSpec{
-		Resources: map[string]schema.ResourceSpec{
-			"my-pkg:index:MyResource": {
-				InputProperties: map[string]schema.PropertySpec{
-					"name": {TypeSpec: schema.TypeSpec{Type: "string"}},
-				},
-				ObjectTypeSpec: schema.ObjectTypeSpec{
-					Properties: map[string]schema.PropertySpec{
-						"value": {TypeSpec: schema.TypeSpec{Type: "string"}},
-					},
-				},
-			},
-		},
-	}
-	newSchema := schema.PackageSpec{
-		Resources: map[string]schema.ResourceSpec{
-			"my-pkg:index:MyResource": {
-				InputProperties: map[string]schema.PropertySpec{},
-				ObjectTypeSpec: schema.ObjectTypeSpec{
-					Properties: map[string]schema.PropertySpec{
-						"value": {TypeSpec: schema.TypeSpec{Type: "number"}},
-					},
-				},
-			},
-		},
-	}
-
+	oldSchema, newSchema := mustLoadFixtureSchemas(t)
 	result := Compare(oldSchema, newSchema, CompareOptions{Provider: "my-pkg", MaxChanges: -1})
 
-	if len(result.Summary) == 0 {
-		t.Fatalf("expected summary entries")
+	wantCategories := []string{
+		"missing-function",
+		"missing-resource",
+		"optional-to-required",
+		"required-to-optional",
+		"type-changed",
 	}
-
-	seenMissingInput := false
-	seenTypeChanged := false
+	gotCategories := make([]string, 0, len(result.Summary))
+	gotCounts := map[string]int{}
+	gotEntries := map[string][]string{}
 	for _, item := range result.Summary {
-		if item.Category == "missing-input" {
-			seenMissingInput = true
-			if item.Count != 1 {
-				t.Fatalf("expected missing-input count 1, got %d", item.Count)
-			}
-			if len(item.Entries) == 0 {
-				t.Fatalf("expected missing-input entries, got %+v", item)
-			}
-		}
-		if item.Category == "type-changed" {
-			seenTypeChanged = true
-			if item.Count != 1 {
-				t.Fatalf("expected type-changed count 1, got %d", item.Count)
-			}
-			if len(item.Entries) == 0 {
-				t.Fatalf("expected type-changed entries, got %+v", item)
-			}
+		gotCategories = append(gotCategories, item.Category)
+		gotCounts[item.Category] = item.Count
+		gotEntries[item.Category] = item.Entries
+		if !sort.StringsAreSorted(item.Entries) {
+			t.Fatalf("entries for %q are not sorted: %v", item.Category, item.Entries)
 		}
 	}
 
-	if !seenMissingInput {
-		t.Fatalf("expected missing-input category in summary")
+	if !reflect.DeepEqual(gotCategories, wantCategories) {
+		t.Fatalf("summary categories mismatch: got %v want %v", gotCategories, wantCategories)
 	}
-	if !seenTypeChanged {
-		t.Fatalf("expected type-changed category in summary")
+	if !reflect.DeepEqual(gotCounts, expectedFixtureSummaryCounts()) {
+		t.Fatalf("summary counts mismatch: got %v want %v", gotCounts, expectedFixtureSummaryCounts())
+	}
+	if !reflect.DeepEqual(gotEntries, expectedFixtureSummaryEntries()) {
+		t.Fatalf("summary entries mismatch:\n got: %v\nwant: %v", gotEntries, expectedFixtureSummaryEntries())
+	}
+}
+
+func mustLoadFixtureSchemas(t testing.TB) (schema.PackageSpec, schema.PackageSpec) {
+	t.Helper()
+	oldSchema := mustReadFixtureSchema(t, "schema-old.json")
+	newSchema := mustReadFixtureSchema(t, "schema-new.json")
+	return oldSchema, newSchema
+}
+
+func mustReadFixtureSchema(t testing.TB, name string) schema.PackageSpec {
+	t.Helper()
+	data := mustReadTestdataFile(t, name)
+	var spec schema.PackageSpec
+	if err := json.Unmarshal(data, &spec); err != nil {
+		t.Fatalf("failed to unmarshal fixture %q: %v", name, err)
+	}
+	return spec
+}
+
+func mustReadTestdataFile(t testing.TB, name string) []byte {
+	t.Helper()
+	path := filepath.Join("..", "..", "testdata", "compare", name)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", path, err)
+	}
+	return data
+}
+
+func expectedFixtureSummaryCounts() map[string]int {
+	return map[string]int{
+		"missing-function":     1,
+		"missing-resource":     1,
+		"optional-to-required": 3,
+		"required-to-optional": 2,
+		"type-changed":         1,
+	}
+}
+
+func expectedFixtureSummaryEntries() map[string][]string {
+	return map[string][]string{
+		"missing-function": {
+			`Functions: "my-pkg:index:removedFunction" missing`,
+		},
+		"missing-resource": {
+			`Resources: "my-pkg:index:RemovedResource" missing`,
+		},
+		"optional-to-required": {
+			`Functions: "my-pkg:index:MyFunction": inputs: required: "arg" input has changed to Required`,
+			`Resources: "my-pkg:index:MyResource": required inputs: "count" input has changed to Required`,
+			`Types: "my-pkg:index:MyType": required: "count" property has changed to Required`,
+		},
+		"required-to-optional": {
+			`Resources: "my-pkg:index:MyResource": required: "value" property is no longer Required`,
+			`Types: "my-pkg:index:MyType": required: "field" property is no longer Required`,
+		},
+		"type-changed": {
+			`Types: "my-pkg:index:MyType": properties: "field" type changed from "string" to "integer"`,
+		},
 	}
 }
 
@@ -119,4 +154,16 @@ func equalStrings(got, want []string) bool {
 		}
 	}
 	return true
+}
+
+func compareLines(text string) []string {
+	lines := strings.Split(text, "\n")
+	out := make([]string, 0, len(lines))
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
 }

--- a/pkg/compare/render_json_test.go
+++ b/pkg/compare/render_json_test.go
@@ -2,6 +2,8 @@ package compare
 
 import (
 	"bytes"
+	"encoding/json"
+	"reflect"
 	"testing"
 )
 
@@ -80,4 +82,64 @@ func TestRenderJSONSummaryOnly(t *testing.T) {
 	if !bytes.Contains(out.Bytes(), []byte("missing-input")) || !bytes.Contains(out.Bytes(), []byte("e1")) {
 		t.Fatalf("expected summary entries in summary-only output, got %s", out.String())
 	}
+}
+
+func TestRenderJSONFixtureContent(t *testing.T) {
+	oldSchema, newSchema := mustLoadFixtureSchemas(t)
+	result := Compare(oldSchema, newSchema, CompareOptions{Provider: "my-pkg", MaxChanges: -1})
+
+	t.Run("full", func(t *testing.T) {
+		var out bytes.Buffer
+		if err := RenderJSON(&out, result, false); err != nil {
+			t.Fatalf("RenderJSON failed: %v", err)
+		}
+
+		var payload fullJSON
+		if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+			t.Fatalf("failed to unmarshal full payload: %v", err)
+		}
+
+		if got, want := payload.BreakingChanges, result.BreakingChanges; !reflect.DeepEqual(got, want) {
+			t.Fatalf("breaking changes mismatch: got %v want %v", got, want)
+		}
+		if len(payload.NewResources) != 0 || len(payload.NewFunctions) != 0 {
+			t.Fatalf("expected no new resources/functions, got resources=%v functions=%v", payload.NewResources, payload.NewFunctions)
+		}
+
+		gotSummaryCounts := map[string]int{}
+		for _, item := range payload.Summary {
+			if len(item.Entries) != 0 {
+				t.Fatalf("full JSON summary must omit entries, found %v in %q", item.Entries, item.Category)
+			}
+			gotSummaryCounts[item.Category] = item.Count
+		}
+		if !reflect.DeepEqual(gotSummaryCounts, expectedFixtureSummaryCounts()) {
+			t.Fatalf("summary count mismatch: got %v want %v", gotSummaryCounts, expectedFixtureSummaryCounts())
+		}
+	})
+
+	t.Run("summary", func(t *testing.T) {
+		var out bytes.Buffer
+		if err := RenderJSON(&out, result, true); err != nil {
+			t.Fatalf("RenderJSON failed: %v", err)
+		}
+
+		var payload summaryOnlyJSON
+		if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+			t.Fatalf("failed to unmarshal summary payload: %v", err)
+		}
+
+		gotEntries := map[string][]string{}
+		gotCounts := map[string]int{}
+		for _, item := range payload.Summary {
+			gotEntries[item.Category] = item.Entries
+			gotCounts[item.Category] = item.Count
+		}
+		if !reflect.DeepEqual(gotCounts, expectedFixtureSummaryCounts()) {
+			t.Fatalf("summary counts mismatch: got %v want %v", gotCounts, expectedFixtureSummaryCounts())
+		}
+		if !reflect.DeepEqual(gotEntries, expectedFixtureSummaryEntries()) {
+			t.Fatalf("summary entries mismatch:\n got: %v\nwant: %v", gotEntries, expectedFixtureSummaryEntries())
+		}
+	})
 }

--- a/testdata/compare/schema-new.json
+++ b/testdata/compare/schema-new.json
@@ -1,0 +1,64 @@
+{
+  "name": "my-pkg",
+  "version": "1.1.0",
+  "resources": {
+    "my-pkg:index:MyResource": {
+      "inputProperties": {
+        "name": {
+          "type": "string"
+        },
+        "count": {
+          "type": "integer"
+        }
+      },
+      "requiredInputs": [
+        "name",
+        "count"
+      ],
+      "properties": {
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": []
+    }
+  },
+  "functions": {
+    "my-pkg:index:MyFunction": {
+      "inputs": {
+        "properties": {
+          "arg": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "arg"
+        ]
+      },
+      "outputs": {
+        "properties": {
+          "result": {
+            "type": "string"
+          }
+        },
+        "required": []
+      }
+    }
+  },
+  "types": {
+    "my-pkg:index:MyType": {
+      "type": "object",
+      "properties": {
+        "field": {
+          "type": "integer"
+        },
+        "count": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "count"
+      ]
+    }
+  }
+}

--- a/testdata/compare/schema-old.json
+++ b/testdata/compare/schema-old.json
@@ -1,0 +1,92 @@
+{
+  "name": "my-pkg",
+  "version": "1.0.0",
+  "resources": {
+    "my-pkg:index:RemovedResource": {
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    "my-pkg:index:MyResource": {
+      "inputProperties": {
+        "name": {
+          "type": "string"
+        },
+        "count": {
+          "type": "integer"
+        }
+      },
+      "requiredInputs": [
+        "name"
+      ],
+      "properties": {
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    }
+  },
+  "functions": {
+    "my-pkg:index:removedFunction": {
+      "inputs": {
+        "properties": {
+          "arg": {
+            "type": "string"
+          }
+        },
+        "required": []
+      },
+      "outputs": {
+        "properties": {
+          "result": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "result"
+        ]
+      }
+    },
+    "my-pkg:index:MyFunction": {
+      "inputs": {
+        "properties": {
+          "arg": {
+            "type": "string"
+          }
+        },
+        "required": []
+      },
+      "outputs": {
+        "properties": {
+          "result": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "result"
+        ]
+      }
+    }
+  },
+  "types": {
+    "my-pkg:index:MyType": {
+      "type": "object",
+      "properties": {
+        "field": {
+          "type": "string"
+        },
+        "count": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "field"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add fixture-driven compare tests for missing resource/function, type changes, and requiredness changes
- expand deterministic assertions for JSON/text/CLI compare renderers
- add local test fixtures under `testdata/compare` to keep tests isolated from network/remote git

## Validation
- go test ./...