### PR TITLE
test(compare): comprehensive tests for compare API and renderers

### DIFF
--- a/internal/cmd/compare_test.go
+++ b/internal/cmd/compare_test.go
@@ -60,8 +60,14 @@ func TestRenderCompareOutputModes(t *testing.T) {
 		err := renderCompareOutput(&out, result, true, true)
 		assert.NoError(t, err)
 		assert.Contains(t, out.String(), `"summary": [`)
+		assert.Contains(t, out.String(), `"missing-input"`)
+		assert.Contains(t, out.String(), `"entries": [`)
 		assert.NotContains(t, out.String(), `"line-1"`)
 		assert.NotContains(t, out.String(), `"r1"`)
+		assert.NotContains(t, out.String(), `"f1"`)
+		assert.NotContains(t, out.String(), `"breaking_changes":`)
+		assert.NotContains(t, out.String(), `"new_resources":`)
+		assert.NotContains(t, out.String(), `"new_functions":`)
 	})
 
 	t.Run("summary write error", func(t *testing.T) {

--- a/pkg/compare/render_summary_test.go
+++ b/pkg/compare/render_summary_test.go
@@ -44,6 +44,17 @@ func TestRenderSummaryWriteError(t *testing.T) {
 	}
 }
 
+func TestRenderSummaryEmpty(t *testing.T) {
+	var out bytes.Buffer
+	err := RenderSummary(&out, CompareResult{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.String() != "No breaking changes found.\n" {
+		t.Fatalf("unexpected empty summary output: %q", out.String())
+	}
+}
+
 type failingWriter struct{}
 
 func (failingWriter) Write(p []byte) (int, error) {


### PR DESCRIPTION
## Summary

  Adds targeted follow-up test coverage for compare output error/contract behavior on top of `st-ac3.3`.

 ## Included in this PR

  - Add writer-failure coverage for compare output paths.
  - Tighten summary-only JSON contract assertions.
  - Tighten summary renderer assertions for empty-summary behavior.
  - Extend CLI compare tests to cover these output-mode expectations.

 ## Validation

  - `go test ./...`

  ## Stack

  - Base: `feat/st-ac3.3-compare-output-modes`
  - Branch: `feat/st-ac3.4-compare-comprehensive-tests`
