### PR TITLE
Add structured diagnostics contract in compare engine

### DIFF
--- a/internal/compare/engine.go
+++ b/internal/compare/engine.go
@@ -1,6 +1,9 @@
 package compare
 
 import (
+	"strconv"
+	"strings"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 
 	"github.com/pulumi/schema-tools/internal/util/diagtree"
@@ -21,8 +24,10 @@ func Analyze(provider string, oldSchema, newSchema schema.PackageSpec) Report {
 		}
 	}
 
+	violations := BreakingChanges(oldSchema, newSchema)
 	return Report{
-		Violations:   BreakingChanges(oldSchema, newSchema),
+		Violations:   violations,
+		Diagnostics:  flattenDiagnostics(violations),
 		NewResources: newResources,
 		NewFunctions: newFunctions,
 	}
@@ -244,4 +249,40 @@ func validateTypes(old *schema.TypeSpec, new *schema.TypeSpec, msg *diagtree.Nod
 
 	validateTypes(old.Items, new.Items, msg.Label("items"))
 	validateTypes(old.AdditionalProperties, new.AdditionalProperties, msg.Label("additional properties"))
+}
+
+func flattenDiagnostics(root *diagtree.Node) []Diagnostic {
+	if root == nil {
+		return []Diagnostic{}
+	}
+	diagnostics := []Diagnostic{}
+	root.WalkDisplayed(func(node *diagtree.Node) {
+		if node == nil || node.Description == "" {
+			return
+		}
+		parts := node.PathTitles()
+		d := Diagnostic{
+			Path:        strings.Join(parts, ": "),
+			Description: node.Description,
+		}
+		if len(parts) > 0 {
+			d.Scope = parts[0]
+		}
+		if len(parts) > 1 {
+			d.Token = maybeUnquote(parts[1])
+		}
+		if len(parts) > 2 {
+			d.Location = parts[2]
+		}
+		diagnostics = append(diagnostics, d)
+	})
+	return diagnostics
+}
+
+func maybeUnquote(v string) string {
+	u, err := strconv.Unquote(v)
+	if err != nil {
+		return v
+	}
+	return u
 }

--- a/internal/compare/engine_test.go
+++ b/internal/compare/engine_test.go
@@ -60,4 +60,54 @@ func TestAnalyzeListsOnlyNewResourcesAndFunctions(t *testing.T) {
 			t.Fatalf("unexpected new function %q (all: %v)", function, report.NewFunctions)
 		}
 	}
+	if len(report.Diagnostics) != 0 {
+		t.Fatalf("expected no diagnostics, got %v", report.Diagnostics)
+	}
+}
+
+func TestAnalyzeFlattensDiagnostics(t *testing.T) {
+	oldSchema := schema.PackageSpec{
+		Resources: map[string]schema.ResourceSpec{
+			"my-pkg:index:Res": {
+				InputProperties: map[string]schema.PropertySpec{
+					"name": {TypeSpec: schema.TypeSpec{Type: "string"}},
+				},
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"name": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+			},
+		},
+	}
+	newSchema := schema.PackageSpec{
+		Resources: map[string]schema.ResourceSpec{
+			"my-pkg:index:Res": {
+				InputProperties: map[string]schema.PropertySpec{},
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"name": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+			},
+		},
+	}
+
+	report := Analyze("my-pkg", oldSchema, newSchema)
+	if len(report.Diagnostics) == 0 {
+		t.Fatal("expected diagnostics to be emitted")
+	}
+	first := report.Diagnostics[0]
+	if first.Scope != "Resources" {
+		t.Fatalf("unexpected diagnostic scope: %+v", first)
+	}
+	if first.Token != "my-pkg:index:Res" {
+		t.Fatalf("unexpected diagnostic token: %+v", first)
+	}
+	if first.Location != "inputs" {
+		t.Fatalf("unexpected diagnostic location: %+v", first)
+	}
+	if first.Path == "" || first.Description == "" {
+		t.Fatalf("diagnostic path/description must be set: %+v", first)
+	}
 }

--- a/internal/compare/model.go
+++ b/internal/compare/model.go
@@ -2,9 +2,19 @@ package compare
 
 import "github.com/pulumi/schema-tools/internal/util/diagtree"
 
+// Diagnostic is a flattened engine violation entry.
+type Diagnostic struct {
+	Scope       string
+	Token       string
+	Location    string
+	Path        string
+	Description string
+}
+
 // Report captures the compare engine output used by text and JSON renderers.
 type Report struct {
 	Violations   *diagtree.Node
+	Diagnostics  []Diagnostic
 	NewResources []string
 	NewFunctions []string
 }


### PR DESCRIPTION
## Summary
- Adds structured diagnostics in the compare engine report (`Scope`, `Token`, `Location`, `Path`, `Description`) by flattening displayed diagnostic tree nodes.
- Preserves existing compare rule detection while establishing a stable engine contract for downstream structured change mapping.
- Adds compare engine tests that validate the new diagnostic shape.

## Why now / user impact
- Later compare output work depends on a typed diagnostic contract instead of parsing display strings.
- This keeps classifier/rendering behavior stable while making output shaping deterministic.

## Before / After
Before (tree-only display diagnostics):
```text
Resources: "pkg:index:Res": inputs: "name" missing
```

After (typed diagnostic records):
```json
{"scope":"Resources","token":"pkg:index:Res","location":"inputs","path":"Resources: \"pkg:index:Res\": inputs: \"name\"","description":"missing"}
```

## Testing
- `go test ./internal/compare`