### PR TITLE
Add aws-mini fixtures and structured golden coverage

### DIFF
--- a/compare/structured_golden_test.go
+++ b/compare/structured_golden_test.go
@@ -1,0 +1,100 @@
+package compare
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+)
+
+func TestStructuredAWSMiniFixturesLoad(t *testing.T) {
+	oldSchema := mustReadAWSMiniSchema(t, "schema-v6.83.0.json")
+	newSchema := mustReadAWSMiniSchema(t, "schema-v7.0.0.json")
+	mustReadAWSMiniMetadata(t, "metadata-v6.83.0.json")
+	mustReadAWSMiniMetadata(t, "metadata-v7.0.0.json")
+
+	requiredResourcesBoth := []string{
+		"aws:s3/bucket:Bucket",
+		"aws:paymentcryptography/key:Key",
+		"aws:cur/reportDefinition:ReportDefinition",
+		"aws:eks/cluster:Cluster",
+	}
+	for _, token := range requiredResourcesBoth {
+		if _, ok := oldSchema.Resources[token]; !ok {
+			t.Fatalf("old schema missing resource token %q", token)
+		}
+		if _, ok := newSchema.Resources[token]; !ok {
+			t.Fatalf("new schema missing resource token %q", token)
+		}
+	}
+	requiredResourcesOldOnly := []string{
+		"aws:chime/voiceConnectorOrganization:VoiceConnectorOrganization",
+	}
+	for _, token := range requiredResourcesOldOnly {
+		if _, ok := oldSchema.Resources[token]; !ok {
+			t.Fatalf("old schema missing resource token %q", token)
+		}
+		if _, ok := newSchema.Resources[token]; ok {
+			t.Fatalf("new schema should not contain old-only resource token %q", token)
+		}
+	}
+
+	requiredFunctions := []string{
+		"aws:lb/getListenerRule:getListenerRule",
+		"aws:bedrock/getInferenceProfiles:getInferenceProfiles",
+	}
+	for _, token := range requiredFunctions {
+		if _, ok := oldSchema.Functions[token]; !ok {
+			t.Fatalf("old schema missing function token %q", token)
+		}
+		if _, ok := newSchema.Functions[token]; !ok {
+			t.Fatalf("new schema missing function token %q", token)
+		}
+	}
+
+	requiredTypes := []string{
+		"aws:paymentcryptography/KeyKeyAttributes:KeyKeyAttributes",
+		"aws:eks/ClusterCertificateAuthority:ClusterCertificateAuthority",
+		"aws:ssoadmin/getApplicationPortalOption:getApplicationPortalOption",
+	}
+	for _, token := range requiredTypes {
+		if _, ok := oldSchema.Types[token]; !ok {
+			t.Fatalf("old schema missing type token %q", token)
+		}
+		if _, ok := newSchema.Types[token]; !ok {
+			t.Fatalf("new schema missing type token %q", token)
+		}
+	}
+}
+
+func mustReadAWSMiniSchema(t testing.TB, name string) schema.PackageSpec {
+	t.Helper()
+	data := mustReadAWSMiniFixtureFile(t, name)
+	var pkg schema.PackageSpec
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		t.Fatalf("failed to parse aws mini schema %q: %v", name, err)
+	}
+	return pkg
+}
+
+func mustReadAWSMiniMetadata(t testing.TB, name string) map[string]any {
+	t.Helper()
+	data := mustReadAWSMiniFixtureFile(t, name)
+	var payload map[string]any
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("failed to parse aws mini metadata %q: %v", name, err)
+	}
+	return payload
+}
+
+func mustReadAWSMiniFixtureFile(t testing.TB, name string) []byte {
+	t.Helper()
+	path := filepath.Join("..", "testdata", "compare-v2", "aws-mini", name)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", path, err)
+	}
+	return data
+}

--- a/compare/testdata/structured/aws-mini.golden.json
+++ b/compare/testdata/structured/aws-mini.golden.json
@@ -1,0 +1,510 @@
+{
+  "summary": [
+    {
+      "category": "deprecated-resource-alias",
+      "count": 1,
+      "entries": [
+        "Resources: \"aws:s3/bucketAclV2:BucketAclV2\" retained as deprecated alias; migrate to \"aws:s3/bucketAcl:BucketAcl\""
+      ]
+    },
+    {
+      "category": "max-items-one-changed",
+      "count": 10,
+      "entries": [
+        "Functions: \"aws:lb/getListenerRule:getListenerRule\": inputs: \"action[*].forward\" \"action[*].forward\" renamed to \"action[*].forwards\" and type changed from \"#/types/aws:lb/GetListenerRuleActionForward:GetListenerRuleActionForward\" to \"array\"",
+        "Resources: \"aws:eks/cluster:Cluster\": properties: \"certificateAuthorities\" \"certificateAuthorities\" renamed to \"certificateAuthority\" and type changed from \"array\" to \"#/types/aws:eks/ClusterCertificateAuthority:ClusterCertificateAuthority\"",
+        "Resources: \"aws:paymentcryptography/key:Key\": inputs: \"keyAttributes\" \"keyAttributes\" type changed from \"array\" to \"#/types/aws:paymentcryptography/KeyKeyAttributes:KeyKeyAttributes\"",
+        "Resources: \"aws:paymentcryptography/key:Key\": properties: \"keyAttributes\" \"keyAttributes\" type changed from \"array\" to \"#/types/aws:paymentcryptography/KeyKeyAttributes:KeyKeyAttributes\"",
+        "Resources: \"aws:s3/bucket:Bucket\": inputs: \"loggings\" \"loggings\" renamed to \"logging\" and type changed from \"array\" to \"#/types/aws:s3/BucketLogging:BucketLogging\"",
+        "Resources: \"aws:s3/bucket:Bucket\": inputs: \"versionings\" \"versionings\" renamed to \"versioning\" and type changed from \"array\" to \"#/types/aws:s3/BucketVersioning:BucketVersioning\"",
+        "Resources: \"aws:s3/bucket:Bucket\": inputs: \"websites\" \"websites\" renamed to \"website\" and type changed from \"array\" to \"#/types/aws:s3/BucketWebsite:BucketWebsite\"",
+        "Resources: \"aws:s3/bucket:Bucket\": properties: \"loggings\" \"loggings\" renamed to \"logging\" and type changed from \"array\" to \"#/types/aws:s3/BucketLogging:BucketLogging\"",
+        "Resources: \"aws:s3/bucket:Bucket\": properties: \"versionings\" \"versionings\" renamed to \"versioning\" and type changed from \"array\" to \"#/types/aws:s3/BucketVersioning:BucketVersioning\"",
+        "Resources: \"aws:s3/bucket:Bucket\": properties: \"websites\" \"websites\" renamed to \"website\" and type changed from \"array\" to \"#/types/aws:s3/BucketWebsite:BucketWebsite\""
+      ]
+    },
+    {
+      "category": "missing-input",
+      "count": 1,
+      "entries": [
+        "Resources: \"aws:eks/cluster:Cluster\": inputs: \"defaultAddonsToRemoves\" missing"
+      ]
+    },
+    {
+      "category": "missing-output",
+      "count": 2,
+      "entries": [
+        "Resources: \"aws:eks/cluster:Cluster\": properties: \"certificateAuthority\" missing output \"certificateAuthority\"",
+        "Resources: \"aws:eks/cluster:Cluster\": properties: \"defaultAddonsToRemoves\" missing output \"defaultAddonsToRemoves\""
+      ]
+    },
+    {
+      "category": "missing-resource",
+      "count": 1,
+      "entries": [
+        "Resources: \"aws:chime/voiceConnectorOrganization:VoiceConnectorOrganization\" missing"
+      ]
+    },
+    {
+      "category": "optional-to-required",
+      "count": 2,
+      "entries": [
+        "Resources: \"aws:cur/reportDefinition:ReportDefinition\": required inputs: \"s3Prefix\" input has changed to Required",
+        "Types: \"aws:ssoadmin/getApplicationPortalOption:getApplicationPortalOption\": required: \"signInOptions\" property has changed to Required"
+      ]
+    },
+    {
+      "category": "signature-changed",
+      "count": 1,
+      "entries": [
+        "Functions: \"aws:bedrock/getInferenceProfiles:getInferenceProfiles\" signature change (pulumi.InvokeOptions)-\u003eT =\u003e (Args, pulumi.InvokeOptions)-\u003eT"
+      ]
+    }
+  ],
+  "changes": [
+    {
+      "scope": "resource",
+      "token": "aws:chime/voiceConnectorOrganization:VoiceConnectorOrganization",
+      "path": "Resources: \"aws:chime/voiceConnectorOrganization:VoiceConnectorOrganization\"",
+      "kind": "missing-resource",
+      "severity": "error",
+      "breaking": true,
+      "source": "engine",
+      "message": "missing"
+    },
+    {
+      "scope": "resource",
+      "token": "aws:cur/reportDefinition:ReportDefinition",
+      "location": "required inputs",
+      "path": "Resources: \"aws:cur/reportDefinition:ReportDefinition\": required inputs: \"s3Prefix\"",
+      "kind": "optional-to-required",
+      "severity": "error",
+      "breaking": true,
+      "source": "engine",
+      "message": "input has changed to Required"
+    },
+    {
+      "scope": "resource",
+      "token": "aws:eks/cluster:Cluster",
+      "location": "inputs",
+      "path": "Resources: \"aws:eks/cluster:Cluster\": inputs: \"defaultAddonsToRemoves\"",
+      "kind": "missing-input",
+      "severity": "warn",
+      "breaking": true,
+      "source": "engine",
+      "message": "missing"
+    },
+    {
+      "scope": "resource",
+      "token": "aws:eks/cluster:Cluster",
+      "location": "properties",
+      "path": "Resources: \"aws:eks/cluster:Cluster\": properties: \"certificateAuthorities\"",
+      "kind": "max-items-one-changed",
+      "severity": "error",
+      "breaking": true,
+      "source": "normalize",
+      "message": "\"certificateAuthorities\" renamed to \"certificateAuthority\" and type changed from \"array\" to \"#/types/aws:eks/ClusterCertificateAuthority:ClusterCertificateAuthority\""
+    },
+    {
+      "scope": "resource",
+      "token": "aws:eks/cluster:Cluster",
+      "location": "properties",
+      "path": "Resources: \"aws:eks/cluster:Cluster\": properties: \"certificateAuthority\"",
+      "kind": "missing-output",
+      "severity": "warn",
+      "breaking": true,
+      "source": "engine",
+      "message": "missing output \"certificateAuthority\""
+    },
+    {
+      "scope": "resource",
+      "token": "aws:eks/cluster:Cluster",
+      "location": "properties",
+      "path": "Resources: \"aws:eks/cluster:Cluster\": properties: \"defaultAddonsToRemoves\"",
+      "kind": "missing-output",
+      "severity": "warn",
+      "breaking": true,
+      "source": "engine",
+      "message": "missing output \"defaultAddonsToRemoves\""
+    },
+    {
+      "scope": "resource",
+      "token": "aws:paymentcryptography/key:Key",
+      "location": "inputs",
+      "path": "Resources: \"aws:paymentcryptography/key:Key\": inputs: \"keyAttributes\"",
+      "kind": "max-items-one-changed",
+      "severity": "error",
+      "breaking": true,
+      "source": "normalize",
+      "message": "\"keyAttributes\" type changed from \"array\" to \"#/types/aws:paymentcryptography/KeyKeyAttributes:KeyKeyAttributes\""
+    },
+    {
+      "scope": "resource",
+      "token": "aws:paymentcryptography/key:Key",
+      "location": "properties",
+      "path": "Resources: \"aws:paymentcryptography/key:Key\": properties: \"keyAttributes\"",
+      "kind": "max-items-one-changed",
+      "severity": "error",
+      "breaking": true,
+      "source": "normalize",
+      "message": "\"keyAttributes\" type changed from \"array\" to \"#/types/aws:paymentcryptography/KeyKeyAttributes:KeyKeyAttributes\""
+    },
+    {
+      "scope": "resource",
+      "token": "aws:s3/bucket:Bucket",
+      "location": "inputs",
+      "path": "Resources: \"aws:s3/bucket:Bucket\": inputs: \"loggings\"",
+      "kind": "max-items-one-changed",
+      "severity": "error",
+      "breaking": true,
+      "source": "normalize",
+      "message": "\"loggings\" renamed to \"logging\" and type changed from \"array\" to \"#/types/aws:s3/BucketLogging:BucketLogging\""
+    },
+    {
+      "scope": "resource",
+      "token": "aws:s3/bucket:Bucket",
+      "location": "inputs",
+      "path": "Resources: \"aws:s3/bucket:Bucket\": inputs: \"versionings\"",
+      "kind": "max-items-one-changed",
+      "severity": "error",
+      "breaking": true,
+      "source": "normalize",
+      "message": "\"versionings\" renamed to \"versioning\" and type changed from \"array\" to \"#/types/aws:s3/BucketVersioning:BucketVersioning\""
+    },
+    {
+      "scope": "resource",
+      "token": "aws:s3/bucket:Bucket",
+      "location": "inputs",
+      "path": "Resources: \"aws:s3/bucket:Bucket\": inputs: \"websites\"",
+      "kind": "max-items-one-changed",
+      "severity": "error",
+      "breaking": true,
+      "source": "normalize",
+      "message": "\"websites\" renamed to \"website\" and type changed from \"array\" to \"#/types/aws:s3/BucketWebsite:BucketWebsite\""
+    },
+    {
+      "scope": "resource",
+      "token": "aws:s3/bucket:Bucket",
+      "location": "properties",
+      "path": "Resources: \"aws:s3/bucket:Bucket\": properties: \"loggings\"",
+      "kind": "max-items-one-changed",
+      "severity": "error",
+      "breaking": true,
+      "source": "normalize",
+      "message": "\"loggings\" renamed to \"logging\" and type changed from \"array\" to \"#/types/aws:s3/BucketLogging:BucketLogging\""
+    },
+    {
+      "scope": "resource",
+      "token": "aws:s3/bucket:Bucket",
+      "location": "properties",
+      "path": "Resources: \"aws:s3/bucket:Bucket\": properties: \"versionings\"",
+      "kind": "max-items-one-changed",
+      "severity": "error",
+      "breaking": true,
+      "source": "normalize",
+      "message": "\"versionings\" renamed to \"versioning\" and type changed from \"array\" to \"#/types/aws:s3/BucketVersioning:BucketVersioning\""
+    },
+    {
+      "scope": "resource",
+      "token": "aws:s3/bucket:Bucket",
+      "location": "properties",
+      "path": "Resources: \"aws:s3/bucket:Bucket\": properties: \"websites\"",
+      "kind": "max-items-one-changed",
+      "severity": "error",
+      "breaking": true,
+      "source": "normalize",
+      "message": "\"websites\" renamed to \"website\" and type changed from \"array\" to \"#/types/aws:s3/BucketWebsite:BucketWebsite\""
+    },
+    {
+      "scope": "resource",
+      "token": "aws:s3/bucketAclV2:BucketAclV2",
+      "path": "Resources: \"aws:s3/bucketAclV2:BucketAclV2\"",
+      "kind": "deprecated-resource-alias",
+      "severity": "info",
+      "breaking": false,
+      "source": "normalize",
+      "message": "retained as deprecated alias; migrate to \"aws:s3/bucketAcl:BucketAcl\""
+    },
+    {
+      "scope": "function",
+      "token": "aws:bedrock/getInferenceProfiles:getInferenceProfiles",
+      "path": "Functions: \"aws:bedrock/getInferenceProfiles:getInferenceProfiles\"",
+      "kind": "signature-changed",
+      "severity": "error",
+      "breaking": true,
+      "source": "engine",
+      "message": "signature change (pulumi.InvokeOptions)-\u003eT =\u003e (Args, pulumi.InvokeOptions)-\u003eT"
+    },
+    {
+      "scope": "function",
+      "token": "aws:lb/getListenerRule:getListenerRule",
+      "location": "inputs",
+      "path": "Functions: \"aws:lb/getListenerRule:getListenerRule\": inputs: \"action[*].forward\"",
+      "kind": "max-items-one-changed",
+      "severity": "error",
+      "breaking": true,
+      "source": "normalize",
+      "message": "\"action[*].forward\" renamed to \"action[*].forwards\" and type changed from \"#/types/aws:lb/GetListenerRuleActionForward:GetListenerRuleActionForward\" to \"array\""
+    },
+    {
+      "scope": "type",
+      "token": "aws:ssoadmin/getApplicationPortalOption:getApplicationPortalOption",
+      "location": "required",
+      "path": "Types: \"aws:ssoadmin/getApplicationPortalOption:getApplicationPortalOption\": required: \"signInOptions\"",
+      "kind": "optional-to-required",
+      "severity": "error",
+      "breaking": true,
+      "source": "engine",
+      "message": "property has changed to Required"
+    }
+  ],
+  "grouped": {
+    "resources": {
+      "aws:chime/voiceConnectorOrganization:VoiceConnectorOrganization": {
+        "general": [
+          {
+            "scope": "resource",
+            "token": "aws:chime/voiceConnectorOrganization:VoiceConnectorOrganization",
+            "path": "Resources: \"aws:chime/voiceConnectorOrganization:VoiceConnectorOrganization\"",
+            "kind": "missing-resource",
+            "severity": "error",
+            "breaking": true,
+            "source": "engine",
+            "message": "missing"
+          }
+        ]
+      },
+      "aws:cur/reportDefinition:ReportDefinition": {
+        "required inputs": [
+          {
+            "scope": "resource",
+            "token": "aws:cur/reportDefinition:ReportDefinition",
+            "location": "required inputs",
+            "path": "Resources: \"aws:cur/reportDefinition:ReportDefinition\": required inputs: \"s3Prefix\"",
+            "kind": "optional-to-required",
+            "severity": "error",
+            "breaking": true,
+            "source": "engine",
+            "message": "input has changed to Required"
+          }
+        ]
+      },
+      "aws:eks/cluster:Cluster": {
+        "inputs": [
+          {
+            "scope": "resource",
+            "token": "aws:eks/cluster:Cluster",
+            "location": "inputs",
+            "path": "Resources: \"aws:eks/cluster:Cluster\": inputs: \"defaultAddonsToRemoves\"",
+            "kind": "missing-input",
+            "severity": "warn",
+            "breaking": true,
+            "source": "engine",
+            "message": "missing"
+          }
+        ],
+        "properties": [
+          {
+            "scope": "resource",
+            "token": "aws:eks/cluster:Cluster",
+            "location": "properties",
+            "path": "Resources: \"aws:eks/cluster:Cluster\": properties: \"certificateAuthorities\"",
+            "kind": "max-items-one-changed",
+            "severity": "error",
+            "breaking": true,
+            "source": "normalize",
+            "message": "\"certificateAuthorities\" renamed to \"certificateAuthority\" and type changed from \"array\" to \"#/types/aws:eks/ClusterCertificateAuthority:ClusterCertificateAuthority\""
+          },
+          {
+            "scope": "resource",
+            "token": "aws:eks/cluster:Cluster",
+            "location": "properties",
+            "path": "Resources: \"aws:eks/cluster:Cluster\": properties: \"certificateAuthority\"",
+            "kind": "missing-output",
+            "severity": "warn",
+            "breaking": true,
+            "source": "engine",
+            "message": "missing output \"certificateAuthority\""
+          },
+          {
+            "scope": "resource",
+            "token": "aws:eks/cluster:Cluster",
+            "location": "properties",
+            "path": "Resources: \"aws:eks/cluster:Cluster\": properties: \"defaultAddonsToRemoves\"",
+            "kind": "missing-output",
+            "severity": "warn",
+            "breaking": true,
+            "source": "engine",
+            "message": "missing output \"defaultAddonsToRemoves\""
+          }
+        ]
+      },
+      "aws:paymentcryptography/key:Key": {
+        "inputs": [
+          {
+            "scope": "resource",
+            "token": "aws:paymentcryptography/key:Key",
+            "location": "inputs",
+            "path": "Resources: \"aws:paymentcryptography/key:Key\": inputs: \"keyAttributes\"",
+            "kind": "max-items-one-changed",
+            "severity": "error",
+            "breaking": true,
+            "source": "normalize",
+            "message": "\"keyAttributes\" type changed from \"array\" to \"#/types/aws:paymentcryptography/KeyKeyAttributes:KeyKeyAttributes\""
+          }
+        ],
+        "properties": [
+          {
+            "scope": "resource",
+            "token": "aws:paymentcryptography/key:Key",
+            "location": "properties",
+            "path": "Resources: \"aws:paymentcryptography/key:Key\": properties: \"keyAttributes\"",
+            "kind": "max-items-one-changed",
+            "severity": "error",
+            "breaking": true,
+            "source": "normalize",
+            "message": "\"keyAttributes\" type changed from \"array\" to \"#/types/aws:paymentcryptography/KeyKeyAttributes:KeyKeyAttributes\""
+          }
+        ]
+      },
+      "aws:s3/bucket:Bucket": {
+        "inputs": [
+          {
+            "scope": "resource",
+            "token": "aws:s3/bucket:Bucket",
+            "location": "inputs",
+            "path": "Resources: \"aws:s3/bucket:Bucket\": inputs: \"loggings\"",
+            "kind": "max-items-one-changed",
+            "severity": "error",
+            "breaking": true,
+            "source": "normalize",
+            "message": "\"loggings\" renamed to \"logging\" and type changed from \"array\" to \"#/types/aws:s3/BucketLogging:BucketLogging\""
+          },
+          {
+            "scope": "resource",
+            "token": "aws:s3/bucket:Bucket",
+            "location": "inputs",
+            "path": "Resources: \"aws:s3/bucket:Bucket\": inputs: \"versionings\"",
+            "kind": "max-items-one-changed",
+            "severity": "error",
+            "breaking": true,
+            "source": "normalize",
+            "message": "\"versionings\" renamed to \"versioning\" and type changed from \"array\" to \"#/types/aws:s3/BucketVersioning:BucketVersioning\""
+          },
+          {
+            "scope": "resource",
+            "token": "aws:s3/bucket:Bucket",
+            "location": "inputs",
+            "path": "Resources: \"aws:s3/bucket:Bucket\": inputs: \"websites\"",
+            "kind": "max-items-one-changed",
+            "severity": "error",
+            "breaking": true,
+            "source": "normalize",
+            "message": "\"websites\" renamed to \"website\" and type changed from \"array\" to \"#/types/aws:s3/BucketWebsite:BucketWebsite\""
+          }
+        ],
+        "properties": [
+          {
+            "scope": "resource",
+            "token": "aws:s3/bucket:Bucket",
+            "location": "properties",
+            "path": "Resources: \"aws:s3/bucket:Bucket\": properties: \"loggings\"",
+            "kind": "max-items-one-changed",
+            "severity": "error",
+            "breaking": true,
+            "source": "normalize",
+            "message": "\"loggings\" renamed to \"logging\" and type changed from \"array\" to \"#/types/aws:s3/BucketLogging:BucketLogging\""
+          },
+          {
+            "scope": "resource",
+            "token": "aws:s3/bucket:Bucket",
+            "location": "properties",
+            "path": "Resources: \"aws:s3/bucket:Bucket\": properties: \"versionings\"",
+            "kind": "max-items-one-changed",
+            "severity": "error",
+            "breaking": true,
+            "source": "normalize",
+            "message": "\"versionings\" renamed to \"versioning\" and type changed from \"array\" to \"#/types/aws:s3/BucketVersioning:BucketVersioning\""
+          },
+          {
+            "scope": "resource",
+            "token": "aws:s3/bucket:Bucket",
+            "location": "properties",
+            "path": "Resources: \"aws:s3/bucket:Bucket\": properties: \"websites\"",
+            "kind": "max-items-one-changed",
+            "severity": "error",
+            "breaking": true,
+            "source": "normalize",
+            "message": "\"websites\" renamed to \"website\" and type changed from \"array\" to \"#/types/aws:s3/BucketWebsite:BucketWebsite\""
+          }
+        ]
+      },
+      "aws:s3/bucketAclV2:BucketAclV2": {
+        "general": [
+          {
+            "scope": "resource",
+            "token": "aws:s3/bucketAclV2:BucketAclV2",
+            "path": "Resources: \"aws:s3/bucketAclV2:BucketAclV2\"",
+            "kind": "deprecated-resource-alias",
+            "severity": "info",
+            "breaking": false,
+            "source": "normalize",
+            "message": "retained as deprecated alias; migrate to \"aws:s3/bucketAcl:BucketAcl\""
+          }
+        ]
+      }
+    },
+    "functions": {
+      "aws:bedrock/getInferenceProfiles:getInferenceProfiles": {
+        "general": [
+          {
+            "scope": "function",
+            "token": "aws:bedrock/getInferenceProfiles:getInferenceProfiles",
+            "path": "Functions: \"aws:bedrock/getInferenceProfiles:getInferenceProfiles\"",
+            "kind": "signature-changed",
+            "severity": "error",
+            "breaking": true,
+            "source": "engine",
+            "message": "signature change (pulumi.InvokeOptions)-\u003eT =\u003e (Args, pulumi.InvokeOptions)-\u003eT"
+          }
+        ]
+      },
+      "aws:lb/getListenerRule:getListenerRule": {
+        "inputs": [
+          {
+            "scope": "function",
+            "token": "aws:lb/getListenerRule:getListenerRule",
+            "location": "inputs",
+            "path": "Functions: \"aws:lb/getListenerRule:getListenerRule\": inputs: \"action[*].forward\"",
+            "kind": "max-items-one-changed",
+            "severity": "error",
+            "breaking": true,
+            "source": "normalize",
+            "message": "\"action[*].forward\" renamed to \"action[*].forwards\" and type changed from \"#/types/aws:lb/GetListenerRuleActionForward:GetListenerRuleActionForward\" to \"array\""
+          }
+        ]
+      }
+    },
+    "types": {
+      "aws:ssoadmin/getApplicationPortalOption:getApplicationPortalOption": {
+        "required": [
+          {
+            "scope": "type",
+            "token": "aws:ssoadmin/getApplicationPortalOption:getApplicationPortalOption",
+            "location": "required",
+            "path": "Types: \"aws:ssoadmin/getApplicationPortalOption:getApplicationPortalOption\": required: \"signInOptions\"",
+            "kind": "optional-to-required",
+            "severity": "error",
+            "breaking": true,
+            "source": "engine",
+            "message": "property has changed to Required"
+          }
+        ]
+      }
+    }
+  },
+  "new_resources": [
+    "s3/bucketAcl.BucketAcl"
+  ],
+  "new_functions": []
+}

--- a/compare/testdata/structured/aws-mini.golden.txt
+++ b/compare/testdata/structured/aws-mini.golden.txt
@@ -1,0 +1,45 @@
+### Does the PR have any schema changes?
+
+Found 17 breaking changes:
+
+#### Resources
+- `🔴` "aws:chime/voiceConnectorOrganization:VoiceConnectorOrganization" missing
+- "aws:cur/reportDefinition:ReportDefinition":
+    - required inputs:
+        - `🔴` "s3Prefix" input has changed to Required
+- "aws:eks/cluster:Cluster":
+    - inputs:
+        - `🟡` "defaultAddonsToRemoves" missing
+    - properties:
+        - `🔴` "certificateAuthorities" renamed to "certificateAuthority" and type changed from "array" to "#/types/aws:eks/ClusterCertificateAuthority:ClusterCertificateAuthority"
+        - `🟡` missing output "certificateAuthority"
+        - `🟡` missing output "defaultAddonsToRemoves"
+- "aws:paymentcryptography/key:Key":
+    - inputs:
+        - `🔴` "keyAttributes" type changed from "array" to "#/types/aws:paymentcryptography/KeyKeyAttributes:KeyKeyAttributes"
+    - properties:
+        - `🔴` "keyAttributes" type changed from "array" to "#/types/aws:paymentcryptography/KeyKeyAttributes:KeyKeyAttributes"
+- "aws:s3/bucket:Bucket":
+    - inputs:
+        - `🔴` "loggings" renamed to "logging" and type changed from "array" to "#/types/aws:s3/BucketLogging:BucketLogging"
+        - `🔴` "versionings" renamed to "versioning" and type changed from "array" to "#/types/aws:s3/BucketVersioning:BucketVersioning"
+        - `🔴` "websites" renamed to "website" and type changed from "array" to "#/types/aws:s3/BucketWebsite:BucketWebsite"
+    - properties:
+        - `🔴` "loggings" renamed to "logging" and type changed from "array" to "#/types/aws:s3/BucketLogging:BucketLogging"
+        - `🔴` "versionings" renamed to "versioning" and type changed from "array" to "#/types/aws:s3/BucketVersioning:BucketVersioning"
+        - `🔴` "websites" renamed to "website" and type changed from "array" to "#/types/aws:s3/BucketWebsite:BucketWebsite"
+
+#### Functions
+- `🔴` "aws:bedrock/getInferenceProfiles:getInferenceProfiles" signature change (pulumi.InvokeOptions)->T => (Args, pulumi.InvokeOptions)->T
+- "aws:lb/getListenerRule:getListenerRule":
+    - inputs:
+        - `🔴` "action[*].forward" renamed to "action[*].forwards" and type changed from "#/types/aws:lb/GetListenerRuleActionForward:GetListenerRuleActionForward" to "array"
+
+#### Types
+- "aws:ssoadmin/getApplicationPortalOption:getApplicationPortalOption":
+    - required:
+        - `🔴` "signInOptions" property has changed to Required
+
+#### New resources:
+
+- `s3/bucketAcl.BucketAcl`

--- a/internal/cmd/compare_structured_golden_test.go
+++ b/internal/cmd/compare_structured_golden_test.go
@@ -1,0 +1,135 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/schema-tools/compare"
+	"github.com/pulumi/schema-tools/internal/normalize"
+)
+
+const updateStructuredGoldenEnv = "SCHEMA_TOOLS_UPDATE_GOLDEN"
+
+func TestCompareV2StructuredGoldens(t *testing.T) {
+	result := mustBuildAWSMiniCompareResult(t)
+
+	t.Run("json", func(t *testing.T) {
+		var out bytes.Buffer
+		if err := renderCompareOutput(&out, result, true, false, -1); err != nil {
+			t.Fatalf("render structured json: %v", err)
+		}
+		assertGoldenBytes(t, compareStructuredGoldenPath("aws-mini.golden.json"), out.Bytes())
+	})
+
+	t.Run("text", func(t *testing.T) {
+		var out bytes.Buffer
+		if err := renderCompareOutput(&out, result, false, false, -1); err != nil {
+			t.Fatalf("render structured text: %v", err)
+		}
+		assertGoldenBytes(t, compareStructuredGoldenPath("aws-mini.golden.txt"), out.Bytes())
+	})
+}
+
+func mustBuildAWSMiniCompareResult(t testing.TB) compare.Result {
+	t.Helper()
+
+	oldSchema := mustReadAWSMiniSchema(t, "schema-v6.83.0.json")
+	newSchema := mustReadAWSMiniSchema(t, "schema-v7.0.0.json")
+	oldMetadata := mustReadAWSMiniMetadataEnvelope(t, "metadata-v6.83.0.json")
+	newMetadata := mustReadAWSMiniMetadataEnvelope(t, "metadata-v7.0.0.json")
+
+	normalized, err := normalize.Normalize(oldSchema, newSchema, oldMetadata, newMetadata)
+	if err != nil {
+		t.Fatalf("normalize aws-mini fixtures: %v", err)
+	}
+
+	result := compare.Schemas(normalized.OldSchema, normalized.NewSchema, compare.Options{Provider: "aws"})
+	return compare.MergeChanges(result, buildNormalizationChanges(normalized.Renames, normalized.MaxItemsOne))
+}
+
+func mustReadAWSMiniSchema(t testing.TB, name string) schema.PackageSpec {
+	t.Helper()
+	data := mustReadAWSMiniFixtureFile(t, name)
+	var spec schema.PackageSpec
+	if err := json.Unmarshal(data, &spec); err != nil {
+		t.Fatalf("parse aws mini schema %q: %v", name, err)
+	}
+	return spec
+}
+
+func mustReadAWSMiniMetadataEnvelope(t testing.TB, name string) *normalize.MetadataEnvelope {
+	t.Helper()
+	data := mustReadAWSMiniFixtureFile(t, name)
+	metadata, err := normalize.ParseMetadata(data)
+	if err != nil {
+		t.Fatalf("parse aws mini metadata %q: %v", name, err)
+	}
+	return metadata
+}
+
+func mustReadAWSMiniFixtureFile(t testing.TB, name string) []byte {
+	t.Helper()
+	path := filepath.Join("..", "..", "testdata", "compare-v2", "aws-mini", name)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", path, err)
+	}
+	return data
+}
+
+func compareStructuredGoldenPath(name string) string {
+	return filepath.Join("..", "..", "compare", "testdata", "structured", name)
+}
+
+func assertGoldenBytes(t testing.TB, path string, got []byte) {
+	t.Helper()
+	if os.Getenv(updateStructuredGoldenEnv) == "1" {
+		if err := os.WriteFile(path, got, 0o600); err != nil {
+			t.Fatalf("update golden %s: %v", path, err)
+		}
+	}
+
+	want, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read golden %s: %v", path, err)
+	}
+	if bytes.Equal(got, want) {
+		return
+	}
+
+	t.Fatalf("golden mismatch: %s\nset %s=1 to update\nwant (%d bytes) != got (%d bytes)\n%s",
+		path, updateStructuredGoldenEnv, len(want), len(got), firstDiffPreview(want, got))
+}
+
+func firstDiffPreview(want, got []byte) string {
+	max := len(want)
+	if len(got) < max {
+		max = len(got)
+	}
+	for i := 0; i < max; i++ {
+		if want[i] != got[i] {
+			start := i - 40
+			if start < 0 {
+				start = 0
+			}
+			endWant := i + 40
+			if endWant > len(want) {
+				endWant = len(want)
+			}
+			endGot := i + 40
+			if endGot > len(got) {
+				endGot = len(got)
+			}
+			return fmt.Sprintf("first diff at byte %d\nwant: %q\ngot:  %q", i, want[start:endWant], got[start:endGot])
+		}
+	}
+	if len(want) != len(got) {
+		return fmt.Sprintf("common prefix length %d; size differs", max)
+	}
+	return "contents differ"
+}

--- a/testdata/compare-v2/aws-mini/metadata-v6.83.0.json
+++ b/testdata/compare-v2/aws-mini/metadata-v6.83.0.json
@@ -1,0 +1,72 @@
+{
+  "auto-aliasing": {
+    "resources": {
+      "aws_s3_bucket_main": {
+        "current": "aws:s3/bucketV2:BucketV2",
+        "majorVersion": 6,
+        "fields": {
+          "logging": {
+            "maxItemsOne": false
+          },
+          "versioning": {
+            "maxItemsOne": false
+          },
+          "website": {
+            "maxItemsOne": false
+          }
+        }
+      },
+      "aws_s3_bucket_legacy": {
+        "current": "aws:s3/bucket:Bucket",
+        "majorVersion": 6
+      },
+      "aws_s3_bucket_acl": {
+        "current": "aws:s3/bucketAclV2:BucketAclV2",
+        "majorVersion": 6
+      },
+      "aws_paymentcryptography_key": {
+        "current": "aws:paymentcryptography/key:Key",
+        "majorVersion": 6,
+        "fields": {
+          "key_attributes": {
+            "maxItemsOne": false
+          }
+        }
+      },
+      "aws_eks_cluster": {
+        "current": "aws:eks/cluster:Cluster",
+        "majorVersion": 6,
+        "fields": {
+          "certificate_authorities": {
+            "maxItemsOne": false
+          },
+          "certificate_authority": {
+            "maxItemsOne": true
+          }
+        }
+      }
+    },
+    "datasources": {
+      "aws_lb_listener_rule": {
+        "current": "aws:lb/getListenerRule:getListenerRule",
+        "majorVersion": 6,
+        "fields": {
+          "action": {
+            "maxItemsOne": false,
+            "elem": {
+              "fields": {
+                "forward": {
+                  "fields": {
+                    "target_group": {
+                      "maxItemsOne": false
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/testdata/compare-v2/aws-mini/metadata-v7.0.0.json
+++ b/testdata/compare-v2/aws-mini/metadata-v7.0.0.json
@@ -1,0 +1,101 @@
+{
+  "auto-aliasing": {
+    "resources": {
+      "aws_s3_bucket_main": {
+        "current": "aws:s3/bucket:Bucket",
+        "past": [
+          {
+            "name": "aws:s3/bucketV2:BucketV2",
+            "inCodegen": true,
+            "majorVersion": 6
+          }
+        ],
+        "majorVersion": 7,
+        "fields": {
+          "logging": {
+            "maxItemsOne": true
+          },
+          "versioning": {
+            "maxItemsOne": true
+          },
+          "website": {
+            "maxItemsOne": true
+          }
+        }
+      },
+      "aws_s3_bucket_v2_compat": {
+        "current": "aws:s3/bucketV2:BucketV2",
+        "past": [
+          {
+            "name": "aws:s3/bucket:Bucket",
+            "inCodegen": true,
+            "majorVersion": 6
+          }
+        ],
+        "majorVersion": 7,
+        "fields": {
+          "logging": {
+            "maxItemsOne": false
+          }
+        }
+      },
+      "aws_s3_bucket_acl": {
+        "current": "aws:s3/bucketAcl:BucketAcl",
+        "past": [
+          {
+            "name": "aws:s3/bucketAclV2:BucketAclV2",
+            "inCodegen": true,
+            "majorVersion": 7
+          }
+        ],
+        "majorVersion": 7
+      },
+      "aws_paymentcryptography_key": {
+        "current": "aws:paymentcryptography/key:Key",
+        "majorVersion": 7,
+        "fields": {
+          "key_attributes": {
+            "maxItemsOne": true
+          }
+        }
+      },
+      "aws_eks_cluster": {
+        "current": "aws:eks/cluster:Cluster",
+        "majorVersion": 7,
+        "fields": {
+          "certificate_authority": {
+            "maxItemsOne": true
+          }
+        }
+      }
+    },
+    "datasources": {
+      "aws_lb_listener_rule": {
+        "current": "aws:lb/getListenerRule:getListenerRule",
+        "majorVersion": 7,
+        "fields": {
+          "action": {
+            "maxItemsOne": false,
+            "elem": {
+              "fields": {
+                "authenticate_cognito": {
+                  "maxItemsOne": false
+                },
+                "forward": {
+                  "maxItemsOne": false,
+                  "elem": {
+                    "fields": {
+                      "target_group": {
+                        "maxItemsOne": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/testdata/compare-v2/aws-mini/schema-v6.83.0.json
+++ b/testdata/compare-v2/aws-mini/schema-v6.83.0.json
@@ -1,0 +1,400 @@
+{
+  "name": "aws",
+  "version": "6.83.0",
+  "resources": {
+    "aws:s3/bucket:Bucket": {
+      "inputProperties": {
+        "loggings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/aws:s3/BucketLogging:BucketLogging"
+          }
+        },
+        "versionings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/aws:s3/BucketVersioning:BucketVersioning"
+          }
+        },
+        "websites": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/aws:s3/BucketWebsite:BucketWebsite"
+          }
+        }
+      },
+      "properties": {
+        "loggings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/aws:s3/BucketLogging:BucketLogging"
+          }
+        },
+        "versionings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/aws:s3/BucketVersioning:BucketVersioning"
+          }
+        },
+        "websites": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/aws:s3/BucketWebsite:BucketWebsite"
+          }
+        }
+      }
+    },
+    "aws:s3/bucketV2:BucketV2": {
+      "inputProperties": {
+        "loggings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/aws:s3/BucketLogging:BucketLogging"
+          }
+        }
+      },
+      "properties": {
+        "loggings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/aws:s3/BucketLogging:BucketLogging"
+          }
+        }
+      }
+    },
+    "aws:s3/bucketAclV2:BucketAclV2": {
+      "inputProperties": {
+        "acl": {
+          "type": "string"
+        }
+      },
+      "requiredInputs": [
+        "acl"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id"
+      ]
+    },
+    "aws:paymentcryptography/key:Key": {
+      "inputProperties": {
+        "keyAttributes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/aws:paymentcryptography/KeyKeyAttributes:KeyKeyAttributes"
+          }
+        }
+      },
+      "properties": {
+        "keyAttributes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/aws:paymentcryptography/KeyKeyAttributes:KeyKeyAttributes"
+          }
+        }
+      }
+    },
+    "aws:chime/voiceConnectorOrganization:VoiceConnectorOrganization": {
+      "inputProperties": {
+        "disabled": {
+          "type": "boolean",
+          "description": "When origination settings are disabled, inbound calls are not enabled for your Amazon Chime Voice Connector.\n"
+        },
+        "routes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/aws:chime/VoiceConnectorOrganizationRoute:VoiceConnectorOrganizationRoute"
+          },
+          "description": "Set of call distribution properties defined for your SIP hosts. See route below for more details. Minimum of 1. Maximum of 20.\n"
+        },
+        "voiceConnectorId": {
+          "type": "string",
+          "description": "The Amazon Chime Voice Connector ID.\n",
+          "willReplaceOnChanges": true
+        }
+      },
+      "requiredInputs": [
+        "routes",
+        "voiceConnectorId"
+      ],
+      "properties": {
+        "disabled": {
+          "type": "boolean",
+          "description": "When origination settings are disabled, inbound calls are not enabled for your Amazon Chime Voice Connector.\n"
+        },
+        "routes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/aws:chime/VoiceConnectorOrganizationRoute:VoiceConnectorOrganizationRoute"
+          },
+          "description": "Set of call distribution properties defined for your SIP hosts. See route below for more details. Minimum of 1. Maximum of 20.\n"
+        },
+        "voiceConnectorId": {
+          "type": "string",
+          "description": "The Amazon Chime Voice Connector ID.\n"
+        }
+      },
+      "required": [
+        "routes",
+        "voiceConnectorId"
+      ]
+    },
+    "aws:cur/reportDefinition:ReportDefinition": {
+      "inputProperties": {
+        "reportName": {
+          "type": "string"
+        },
+        "s3Prefix": {
+          "type": "string"
+        }
+      },
+      "requiredInputs": [
+        "reportName"
+      ],
+      "properties": {
+        "reportName": {
+          "type": "string"
+        },
+        "s3Prefix": {
+          "type": "string"
+        }
+      }
+    },
+    "aws:eks/cluster:Cluster": {
+      "inputProperties": {
+        "defaultAddonsToRemoves": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "properties": {
+        "certificateAuthorities": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/aws:eks/ClusterCertificateAuthority:ClusterCertificateAuthority"
+          }
+        },
+        "certificateAuthority": {
+          "$ref": "#/types/aws:eks/ClusterCertificateAuthority:ClusterCertificateAuthority"
+        },
+        "defaultAddonsToRemoves": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "functions": {
+    "aws:lb/getListenerRule:getListenerRule": {
+      "inputs": {
+        "properties": {
+          "action": {
+            "type": "array",
+            "items": {
+              "$ref": "#/types/aws:lb/GetListenerRuleAction:GetListenerRuleAction"
+            }
+          }
+        }
+      }
+    },
+    "aws:bedrock/getInferenceProfiles:getInferenceProfiles": {
+      "outputs": {
+        "description": "A collection of values returned by getInferenceProfiles.\n",
+        "properties": {
+          "id": {
+            "description": "The provider-assigned unique ID for this managed resource.\n",
+            "type": "string"
+          },
+          "inferenceProfileSummaries": {
+            "description": "List of inference profile summary objects. See `inference_profile_summaries`.\n",
+            "items": {
+              "$ref": "#/types/aws:bedrock/getInferenceProfilesInferenceProfileSummary:getInferenceProfilesInferenceProfileSummary"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "inferenceProfileSummaries",
+          "id"
+        ],
+        "type": "object"
+      }
+    }
+  },
+  "types": {
+    "aws:s3/BucketLogging:BucketLogging": {
+      "type": "object",
+      "properties": {
+        "targetBucket": {
+          "type": "string"
+        }
+      }
+    },
+    "aws:s3/BucketVersioning:BucketVersioning": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      }
+    },
+    "aws:s3/BucketWebsite:BucketWebsite": {
+      "type": "object",
+      "properties": {
+        "indexDocument": {
+          "type": "string"
+        }
+      }
+    },
+    "aws:lb/GetListenerRuleAction:GetListenerRuleAction": {
+      "type": "object",
+      "properties": {
+        "forward": {
+          "$ref": "#/types/aws:lb/GetListenerRuleActionForward:GetListenerRuleActionForward"
+        }
+      }
+    },
+    "aws:lb/GetListenerRuleActionForward:GetListenerRuleActionForward": {
+      "type": "object",
+      "properties": {
+        "targetGroups": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/aws:lb/GetListenerRuleActionForwardTargetGroup:GetListenerRuleActionForwardTargetGroup"
+          }
+        }
+      }
+    },
+    "aws:lb/GetListenerRuleActionForwardTargetGroup:GetListenerRuleActionForwardTargetGroup": {
+      "type": "object",
+      "properties": {
+        "arn": {
+          "type": "string"
+        }
+      }
+    },
+    "aws:paymentcryptography/KeyKeyAttributes:KeyKeyAttributes": {
+      "type": "object",
+      "properties": {
+        "keyModesOfUse": {
+          "type": "string"
+        }
+      }
+    },
+    "aws:eks/ClusterCertificateAuthority:ClusterCertificateAuthority": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "string"
+        }
+      }
+    },
+    "aws:ssoadmin/getApplicationPortalOption:getApplicationPortalOption": {
+      "type": "object",
+      "properties": {
+        "signInOptions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/aws:ssoadmin/getApplicationPortalOptionSignInOption:getApplicationPortalOptionSignInOption"
+          }
+        },
+        "visibility": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "visibility"
+      ]
+    },
+    "aws:bedrock/getInferenceProfilesInferenceProfileSummary:getInferenceProfilesInferenceProfileSummary": {
+      "type": "object",
+      "properties": {
+        "createdAt": {
+          "type": "string",
+          "description": "The time at which the inference profile was created.\n"
+        },
+        "description": {
+          "type": "string",
+          "description": "The description of the inference profile.\n"
+        },
+        "inferenceProfileArn": {
+          "type": "string",
+          "description": "The Amazon Resource Name (ARN) of the inference profile.\n"
+        },
+        "inferenceProfileId": {
+          "type": "string",
+          "description": "The unique identifier of the inference profile.\n"
+        },
+        "inferenceProfileName": {
+          "type": "string",
+          "description": "The name of the inference profile.\n"
+        },
+        "models": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/aws:bedrock/getInferenceProfilesInferenceProfileSummaryModel:getInferenceProfilesInferenceProfileSummaryModel"
+          },
+          "description": "A list of information about each model in the inference profile. See `models`.\n"
+        },
+        "status": {
+          "type": "string",
+          "description": "The status of the inference profile. `ACTIVE` means that the inference profile is available to use.\n"
+        },
+        "type": {
+          "type": "string",
+          "description": "The type of the inference profile. `SYSTEM_DEFINED` means that the inference profile is defined by Amazon Bedrock.\n"
+        },
+        "updatedAt": {
+          "type": "string",
+          "description": "The time at which the inference profile was last updated.\n"
+        }
+      },
+      "required": [
+        "createdAt",
+        "description",
+        "inferenceProfileArn",
+        "inferenceProfileId",
+        "inferenceProfileName",
+        "models",
+        "status",
+        "type",
+        "updatedAt"
+      ]
+    },
+    "aws:bedrock/getInferenceProfilesInferenceProfileSummaryModel:getInferenceProfilesInferenceProfileSummaryModel": {
+      "type": "object",
+      "properties": {
+        "modelArn": {
+          "type": "string",
+          "description": "The Amazon Resource Name (ARN) of the model.\n"
+        }
+      },
+      "required": [
+        "modelArn"
+      ]
+    },
+    "aws:ssoadmin/getApplicationPortalOptionSignInOption:getApplicationPortalOptionSignInOption": {
+      "type": "object",
+      "properties": {
+        "applicationUrl": {
+          "type": "string"
+        },
+        "origin": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "applicationUrl",
+        "origin"
+      ]
+    }
+  }
+}

--- a/testdata/compare-v2/aws-mini/schema-v7.0.0.json
+++ b/testdata/compare-v2/aws-mini/schema-v7.0.0.json
@@ -1,0 +1,368 @@
+{
+  "name": "aws",
+  "version": "7.0.0",
+  "resources": {
+    "aws:s3/bucket:Bucket": {
+      "inputProperties": {
+        "logging": {
+          "$ref": "#/types/aws:s3/BucketLogging:BucketLogging"
+        },
+        "versioning": {
+          "$ref": "#/types/aws:s3/BucketVersioning:BucketVersioning"
+        },
+        "website": {
+          "$ref": "#/types/aws:s3/BucketWebsite:BucketWebsite"
+        }
+      },
+      "properties": {
+        "logging": {
+          "$ref": "#/types/aws:s3/BucketLogging:BucketLogging"
+        },
+        "versioning": {
+          "$ref": "#/types/aws:s3/BucketVersioning:BucketVersioning"
+        },
+        "website": {
+          "$ref": "#/types/aws:s3/BucketWebsite:BucketWebsite"
+        }
+      }
+    },
+    "aws:s3/bucketV2:BucketV2": {
+      "deprecationMessage": "Deprecated in favor of aws:s3/bucket:Bucket.",
+      "inputProperties": {
+        "loggings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/aws:s3/BucketLogging:BucketLogging"
+          }
+        }
+      },
+      "properties": {
+        "loggings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/aws:s3/BucketLogging:BucketLogging"
+          }
+        }
+      }
+    },
+    "aws:s3/bucketAcl:BucketAcl": {
+      "inputProperties": {
+        "acl": {
+          "type": "string"
+        }
+      },
+      "requiredInputs": [
+        "acl"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id"
+      ]
+    },
+    "aws:s3/bucketAclV2:BucketAclV2": {
+      "deprecationMessage": "Deprecated in favor of aws:s3/bucketAcl:BucketAcl.",
+      "inputProperties": {
+        "acl": {
+          "type": "string"
+        }
+      },
+      "requiredInputs": [
+        "acl"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id"
+      ]
+    },
+    "aws:paymentcryptography/key:Key": {
+      "inputProperties": {
+        "keyAttributes": {
+          "$ref": "#/types/aws:paymentcryptography/KeyKeyAttributes:KeyKeyAttributes"
+        }
+      },
+      "properties": {
+        "keyAttributes": {
+          "$ref": "#/types/aws:paymentcryptography/KeyKeyAttributes:KeyKeyAttributes"
+        }
+      }
+    },
+    "aws:cur/reportDefinition:ReportDefinition": {
+      "inputProperties": {
+        "reportName": {
+          "type": "string"
+        },
+        "s3Prefix": {
+          "type": "string"
+        }
+      },
+      "requiredInputs": [
+        "reportName",
+        "s3Prefix"
+      ],
+      "properties": {
+        "reportName": {
+          "type": "string"
+        },
+        "s3Prefix": {
+          "type": "string"
+        }
+      }
+    },
+    "aws:eks/cluster:Cluster": {
+      "inputProperties": {},
+      "properties": {
+        "certificateAuthority": {
+          "$ref": "#/types/aws:eks/ClusterCertificateAuthority:ClusterCertificateAuthority"
+        }
+      }
+    }
+  },
+  "functions": {
+    "aws:lb/getListenerRule:getListenerRule": {
+      "inputs": {
+        "properties": {
+          "action": {
+            "type": "array",
+            "items": {
+              "$ref": "#/types/aws:lb/GetListenerRuleAction:GetListenerRuleAction"
+            }
+          }
+        }
+      }
+    },
+    "aws:bedrock/getInferenceProfiles:getInferenceProfiles": {
+      "inputs": {
+        "description": "A collection of arguments for invoking getInferenceProfiles.\n",
+        "properties": {
+          "region": {
+            "type": "string",
+            "description": "Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the provider configuration.\n"
+          }
+        },
+        "type": "object"
+      },
+      "outputs": {
+        "description": "A collection of values returned by getInferenceProfiles.\n",
+        "properties": {
+          "id": {
+            "description": "The provider-assigned unique ID for this managed resource.\n",
+            "type": "string"
+          },
+          "inferenceProfileSummaries": {
+            "description": "List of inference profile summary objects. See `inference_profile_summaries`.\n",
+            "items": {
+              "$ref": "#/types/aws:bedrock/getInferenceProfilesInferenceProfileSummary:getInferenceProfilesInferenceProfileSummary"
+            },
+            "type": "array"
+          },
+          "region": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "inferenceProfileSummaries",
+          "region",
+          "id"
+        ],
+        "type": "object"
+      }
+    }
+  },
+  "types": {
+    "aws:s3/BucketLogging:BucketLogging": {
+      "type": "object",
+      "properties": {
+        "targetBucket": {
+          "type": "string"
+        }
+      }
+    },
+    "aws:s3/BucketVersioning:BucketVersioning": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      }
+    },
+    "aws:s3/BucketWebsite:BucketWebsite": {
+      "type": "object",
+      "properties": {
+        "indexDocument": {
+          "type": "string"
+        }
+      }
+    },
+    "aws:lb/GetListenerRuleAction:GetListenerRuleAction": {
+      "type": "object",
+      "properties": {
+        "authenticateCognitos": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/aws:lb/GetListenerRuleActionAuthenticateCognito:GetListenerRuleActionAuthenticateCognito"
+          }
+        },
+        "forwards": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/aws:lb/GetListenerRuleActionForward:GetListenerRuleActionForward"
+          }
+        }
+      }
+    },
+    "aws:lb/GetListenerRuleActionAuthenticateCognito:GetListenerRuleActionAuthenticateCognito": {
+      "type": "object",
+      "properties": {
+        "userPoolArn": {
+          "type": "string"
+        }
+      }
+    },
+    "aws:lb/GetListenerRuleActionForward:GetListenerRuleActionForward": {
+      "type": "object",
+      "properties": {
+        "targetGroups": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/aws:lb/GetListenerRuleActionForwardTargetGroup:GetListenerRuleActionForwardTargetGroup"
+          }
+        }
+      }
+    },
+    "aws:lb/GetListenerRuleActionForwardTargetGroup:GetListenerRuleActionForwardTargetGroup": {
+      "type": "object",
+      "properties": {
+        "arn": {
+          "type": "string"
+        }
+      }
+    },
+    "aws:paymentcryptography/KeyKeyAttributes:KeyKeyAttributes": {
+      "type": "object",
+      "properties": {
+        "keyModesOfUse": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "aws:eks/ClusterCertificateAuthority:ClusterCertificateAuthority": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "string"
+        }
+      }
+    },
+    "aws:ssoadmin/getApplicationPortalOption:getApplicationPortalOption": {
+      "type": "object",
+      "properties": {
+        "signInOptions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/aws:ssoadmin/getApplicationPortalOptionSignInOption:getApplicationPortalOptionSignInOption"
+          }
+        },
+        "visibility": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "signInOptions",
+        "visibility"
+      ]
+    },
+    "aws:bedrock/getInferenceProfilesInferenceProfileSummary:getInferenceProfilesInferenceProfileSummary": {
+      "type": "object",
+      "properties": {
+        "createdAt": {
+          "type": "string",
+          "description": "The time at which the inference profile was created.\n"
+        },
+        "description": {
+          "type": "string",
+          "description": "The description of the inference profile.\n"
+        },
+        "inferenceProfileArn": {
+          "type": "string",
+          "description": "The Amazon Resource Name (ARN) of the inference profile.\n"
+        },
+        "inferenceProfileId": {
+          "type": "string",
+          "description": "The unique identifier of the inference profile.\n"
+        },
+        "inferenceProfileName": {
+          "type": "string",
+          "description": "The name of the inference profile.\n"
+        },
+        "models": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/aws:bedrock/getInferenceProfilesInferenceProfileSummaryModel:getInferenceProfilesInferenceProfileSummaryModel"
+          },
+          "description": "A list of information about each model in the inference profile. See `models`.\n"
+        },
+        "status": {
+          "type": "string",
+          "description": "The status of the inference profile. `ACTIVE` means that the inference profile is available to use.\n"
+        },
+        "type": {
+          "type": "string",
+          "description": "The type of the inference profile. `SYSTEM_DEFINED` means that the inference profile is defined by Amazon Bedrock.\n"
+        },
+        "updatedAt": {
+          "type": "string",
+          "description": "The time at which the inference profile was last updated.\n"
+        }
+      },
+      "required": [
+        "createdAt",
+        "description",
+        "inferenceProfileArn",
+        "inferenceProfileId",
+        "inferenceProfileName",
+        "models",
+        "status",
+        "type",
+        "updatedAt"
+      ]
+    },
+    "aws:bedrock/getInferenceProfilesInferenceProfileSummaryModel:getInferenceProfilesInferenceProfileSummaryModel": {
+      "type": "object",
+      "properties": {
+        "modelArn": {
+          "type": "string",
+          "description": "The Amazon Resource Name (ARN) of the model.\n"
+        }
+      },
+      "required": [
+        "modelArn"
+      ]
+    },
+    "aws:ssoadmin/getApplicationPortalOptionSignInOption:getApplicationPortalOptionSignInOption": {
+      "type": "object",
+      "properties": {
+        "applicationUrl": {
+          "type": "string"
+        },
+        "origin": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "applicationUrl",
+        "origin"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds aws-mini compare-v2 fixtures (old/new schemas and bridge metadata) under `testdata/compare-v2/aws-mini`.
- Adds structured output golden coverage for compare package rendering and command-level rendering paths.
- Captures grouped/text output shaping expectations in stable goldens.

## Why now / user impact
- Structured compare output changed materially; we need representative fixture-backed goldens to lock behavior.
- This gives reviewers and future refactors a concrete regression harness for output shape and ordering.

## Before / After
Before:
```text
No aws-mini compare-v2 golden contract for structured `changes`/`grouped` output.
```

After:
```text
testdata/compare-v2/aws-mini/*.golden.json and *.golden.txt assert structured output shape.
```

## Testing
- `go test ./compare ./internal/cmd`