### PR TITLE
Document compare v2 structured output contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,12 +146,16 @@ To emit machine-readable JSON output:
 ```shell
 $ schema-tools compare -p docker -o v3.0.0 -n v4.0.0 --json
 {
-  "summary": [ {"category": "...", "count": 1} ],
-  "breaking_changes": [...],
+  "summary": [ {"category": "...", "count": 1, "entries": ["..."]} ],
+  "changes": [ {"scope": "resource", "token": "...", "kind": "..."} ],
+  "grouped": { "resources": {}, "functions": {}, "types": {} },
   "new_resources": [...],
   "new_functions": [...]
 }
 ```
+
+`--max-changes` applies only to text rendering output. JSON `summary`, `changes`,
+and `grouped` are always based on the full uncapped change set.
 
 To emit summary-only output (category counts only):
 


### PR DESCRIPTION
## Summary
- Updates README examples to reflect the compare-v2 structured JSON contract.
- Documents summary entries in JSON output and clarifies `--max-changes` behavior with structured outputs.

## Why now / user impact
- Without docs, users still expect the older `breaking_changes`-centric output shape.
- This makes CLI behavior and JSON fields explicit for both human readers and automation consumers.

## Before / After
Before:
```json
{"breaking_changes":[...],"new_resources":[...],"new_functions":[...]}
```

After:
```json
{"summary":[...],"changes":[...],"grouped":{...},"new_resources":[...],"new_functions":[...]}
```

## Testing
- Documentation change only