### PR TITLE
Deduplicate compare/cmd fixture loaders via shared helper

### DIFF
--- a/compare/compare_test.go
+++ b/compare/compare_test.go
@@ -1,9 +1,6 @@
 package compare
 
 import (
-	"encoding/json"
-	"os"
-	"path/filepath"
 	"reflect"
 	"slices"
 	"sort"
@@ -12,6 +9,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	internalcompare "github.com/pulumi/schema-tools/internal/compare"
+	"github.com/pulumi/schema-tools/internal/testhelpers"
 )
 
 func TestSchemasSortsNewResourcesAndFunctions(t *testing.T) {
@@ -651,31 +649,11 @@ func TestSchemasClassificationContractWithInternalDiagnostics(t *testing.T) {
 
 func mustLoadFixtureSchemas(t testing.TB) (schema.PackageSpec, schema.PackageSpec) {
 	t.Helper()
-	// Keep in sync with internal/cmd/compare_test.go helpers by design:
-	// tests in these two packages cannot share *_test.go helpers directly.
-	oldSchema := mustReadFixtureSchema(t, "schema-old.json")
-	newSchema := mustReadFixtureSchema(t, "schema-new.json")
-	return oldSchema, newSchema
-}
-
-func mustReadFixtureSchema(t testing.TB, name string) schema.PackageSpec {
-	t.Helper()
-	data := mustReadTestdataFile(t, name)
-	var spec schema.PackageSpec
-	if err := json.Unmarshal(data, &spec); err != nil {
-		t.Fatalf("failed to unmarshal fixture %q: %v", name, err)
-	}
-	return spec
-}
-
-func mustReadTestdataFile(t testing.TB, name string) []byte {
-	t.Helper()
-	path := filepath.Join("..", "testdata", "compare", name)
-	data, err := os.ReadFile(path)
+	oldSchema, newSchema, err := testhelpers.LoadCompareFixtureSchemas()
 	if err != nil {
-		t.Fatalf("failed to read %s: %v", path, err)
+		t.Fatalf("failed to load compare fixtures: %v", err)
 	}
-	return data
+	return oldSchema, newSchema
 }
 
 func expectedFixtureSummaryCounts() map[string]int {

--- a/internal/cmd/compare_test.go
+++ b/internal/cmd/compare_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"os"
 	"os/user"
 	"reflect"
 	"strings"
@@ -16,6 +15,7 @@ import (
 	"github.com/pulumi/schema-tools/compare"
 	"github.com/pulumi/schema-tools/internal/normalize"
 	"github.com/pulumi/schema-tools/internal/pkg"
+	"github.com/pulumi/schema-tools/internal/testhelpers"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -233,7 +233,8 @@ func (errorWriter) Write(p []byte) (int, error) {
 }
 
 func TestCompareSchemasFixtureTextOutput(t *testing.T) {
-	oldSchema, newSchema := mustLoadCompareFixtureSchemas(t)
+	oldSchema, newSchema, err := testhelpers.LoadCompareFixtureSchemas()
+	assert.NoError(t, err)
 
 	var out bytes.Buffer
 	result := compare.Schemas(oldSchema, newSchema, compare.Options{Provider: "my-pkg"})
@@ -251,7 +252,8 @@ func TestCompareSchemasFixtureTextOutput(t *testing.T) {
 }
 
 func TestRenderCompareOutputFixtureJSON(t *testing.T) {
-	oldSchema, newSchema := mustLoadCompareFixtureSchemas(t)
+	oldSchema, newSchema, err := testhelpers.LoadCompareFixtureSchemas()
+	assert.NoError(t, err)
 	result := compare.Schemas(oldSchema, newSchema, compare.Options{Provider: "my-pkg"})
 
 	t.Run("full", func(t *testing.T) {
@@ -313,25 +315,4 @@ func TestRenderCompareOutputFixtureJSON(t *testing.T) {
 			`Types: "my-pkg:index:MyType": required: "count" property has changed to Required`,
 		}, entriesByCategory["optional-to-required"])
 	})
-}
-
-func mustLoadCompareFixtureSchemas(t testing.TB) (schema.PackageSpec, schema.PackageSpec) {
-	t.Helper()
-	// Keep in sync with compare/compare_test.go fixture loaders by design:
-	// package boundaries prevent sharing local *_test.go helpers directly.
-	return mustLoadCompareFixtureSchema(t, "schema-old.json"),
-		mustLoadCompareFixtureSchema(t, "schema-new.json")
-}
-
-func mustLoadCompareFixtureSchema(t testing.TB, name string) schema.PackageSpec {
-	t.Helper()
-	data, err := os.ReadFile("../../testdata/compare/" + name)
-	if err != nil {
-		t.Fatalf("failed to read fixture %s: %v", name, err)
-	}
-	var spec schema.PackageSpec
-	if err := json.Unmarshal(data, &spec); err != nil {
-		t.Fatalf("failed to unmarshal fixture %q: %v", name, err)
-	}
-	return spec
 }

--- a/internal/testhelpers/compare_fixtures.go
+++ b/internal/testhelpers/compare_fixtures.go
@@ -1,0 +1,51 @@
+package testhelpers
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+)
+
+// LoadCompareFixtureSchemas loads the shared compare fixture pair.
+func LoadCompareFixtureSchemas() (schema.PackageSpec, schema.PackageSpec, error) {
+	oldSchema, err := LoadCompareFixtureSchema("schema-old.json")
+	if err != nil {
+		return schema.PackageSpec{}, schema.PackageSpec{}, err
+	}
+	newSchema, err := LoadCompareFixtureSchema("schema-new.json")
+	if err != nil {
+		return schema.PackageSpec{}, schema.PackageSpec{}, err
+	}
+	return oldSchema, newSchema, nil
+}
+
+// LoadCompareFixtureSchema loads one schema fixture from testdata/compare.
+func LoadCompareFixtureSchema(name string) (schema.PackageSpec, error) {
+	fixturesDir, err := compareFixturesDir()
+	if err != nil {
+		return schema.PackageSpec{}, err
+	}
+	path := filepath.Join(fixturesDir, name)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return schema.PackageSpec{}, fmt.Errorf("read compare fixture %q: %w", path, err)
+	}
+
+	var spec schema.PackageSpec
+	if err := json.Unmarshal(data, &spec); err != nil {
+		return schema.PackageSpec{}, fmt.Errorf("unmarshal compare fixture %q: %w", path, err)
+	}
+	return spec, nil
+}
+
+func compareFixturesDir() (string, error) {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("resolve testhelpers source location")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(filename), "..", "..", "testdata", "compare")), nil
+}


### PR DESCRIPTION
## Summary
- Adds shared compare fixture loading utilities in `internal/testhelpers`.
- Replaces duplicated fixture read/unmarshal helpers in `compare/compare_test.go` and `internal/cmd/compare_test.go`.
- Keeps compare and cmd structured fixture tests aligned on one loader path.

## Why now / user impact
- Review feedback flagged duplicated harness logic across compare and cmd tests.
- Centralizing loaders reduces fixture drift risk and keeps structured golden assertions consistent between packages.

## Testing
- `go test ./compare ./internal/cmd`