### PR TITLE
Implement field-path and type-equivalence lookup helpers

### DIFF
--- a/internal/normalize/field_history.go
+++ b/internal/normalize/field_history.go
@@ -1,0 +1,202 @@
+package normalize
+
+import "sort"
+
+type fieldLookupDirection string
+
+const (
+	fieldLookupDirectionOldToNew fieldLookupDirection = "old-to-new"
+	fieldLookupDirectionNewToOld fieldLookupDirection = "new-to-old"
+)
+
+// MaxItemsOneTransition describes old/new maxItemsOne relationship at one field path.
+type MaxItemsOneTransition string
+
+const (
+	// MaxItemsOneTransitionChanged means old/new are both known and differ.
+	MaxItemsOneTransitionChanged MaxItemsOneTransition = "changed"
+	// MaxItemsOneTransitionUnchanged means old/new are both known and equal.
+	MaxItemsOneTransitionUnchanged MaxItemsOneTransition = "unchanged"
+	// MaxItemsOneTransitionUnknown means one side is absent/unspecified.
+	MaxItemsOneTransitionUnknown MaxItemsOneTransition = "unknown"
+)
+
+// FlattenFieldHistory flattens nested field/elem history into dot paths.
+// Example: fields.a.elem.b becomes "a[*].b".
+func FlattenFieldHistory(fields map[string]*FieldHistory) map[string]*bool {
+	if len(fields) == 0 {
+		return map[string]*bool{}
+	}
+
+	out := map[string]*bool{}
+	for _, fieldName := range sortedMapKeys(fields) {
+		flattenFieldHistoryNode(fieldName, fields[fieldName], out)
+	}
+	return out
+}
+
+// ClassifyMaxItemsOneTransition compares old/new maxItemsOne values.
+// Example: old=true and new=false -> MaxItemsOneTransitionChanged.
+func ClassifyMaxItemsOneTransition(oldValue, newValue *bool) MaxItemsOneTransition {
+	if oldValue == nil || newValue == nil {
+		return MaxItemsOneTransitionUnknown
+	}
+	if *oldValue == *newValue {
+		return MaxItemsOneTransitionUnchanged
+	}
+	return MaxItemsOneTransitionChanged
+}
+
+// ResolveField resolves an old-snapshot field path to new-snapshot evidence.
+// Resolution is source-gated: token and field path must exist in source metadata.
+//
+// Example:
+//
+//	result := ResolveField(oldMeta, newMeta, "resources", "pkg:index/widget:Widget", "spec")
+func ResolveField(oldMetadata, newMetadata *MetadataEnvelope, scope, oldToken, oldField string) FieldLookupResult {
+	return resolveField(oldMetadata, newMetadata, fieldLookupDirectionOldToNew, scope, oldToken, oldField)
+}
+
+// ResolveNewField resolves a new-snapshot field path to old-snapshot evidence.
+// Resolution is source-gated: token and field path must exist in source metadata.
+//
+// Example:
+//
+//	result := ResolveNewField(oldMeta, newMeta, "resources", "pkg:index/widgetV2:Widget", "spec")
+func ResolveNewField(oldMetadata, newMetadata *MetadataEnvelope, scope, newToken, newField string) FieldLookupResult {
+	return resolveField(oldMetadata, newMetadata, fieldLookupDirectionNewToOld, scope, newToken, newField)
+}
+
+// resolveField applies direction mapping, source evidence gating, and exact-path
+// transition matching to return none/resolved/ambiguous outcomes.
+func resolveField(
+	oldMetadata, newMetadata *MetadataEnvelope,
+	direction fieldLookupDirection,
+	scope, token, field string,
+) FieldLookupResult {
+	if token == "" || field == "" {
+		return fieldLookupNoneResult()
+	}
+
+	fromMap, toMap := resolveFieldDirectionMaps(oldMetadata, newMetadata, direction, scope)
+	if len(fromMap) == 0 {
+		return fieldLookupNoneResult()
+	}
+
+	sourceMatched := false
+	exactMatch := false
+	weakTargetMiss := false
+	exactTransitions := map[MaxItemsOneTransition]struct{}{}
+	for _, tfToken := range sortedMapKeys(fromMap) {
+		fromHistory := fromMap[tfToken]
+		if !tokenAppearsInHistory(fromHistory, token) {
+			continue
+		}
+
+		fromPaths := flattenTokenFields(fromHistory)
+		fromValue, ok := fromPaths[field]
+		if !ok {
+			continue
+		}
+
+		sourceMatched = true
+		toPaths := flattenTokenFields(toMap[tfToken])
+		toValue, ok := toPaths[field]
+		if !ok {
+			weakTargetMiss = true
+			continue
+		}
+		exactMatch = true
+		exactTransitions[ClassifyMaxItemsOneTransition(fromValue, toValue)] = struct{}{}
+	}
+
+	if !sourceMatched {
+		return fieldLookupNoneResult()
+	}
+
+	if !exactMatch {
+		return fieldLookupNoneResult()
+	}
+
+	if weakTargetMiss || len(exactTransitions) != 1 {
+		return FieldLookupResult{
+			Outcome:    TokenLookupOutcomeAmbiguous,
+			Candidates: []string{field},
+		}
+	}
+
+	for transition := range exactTransitions {
+		return FieldLookupResult{
+			Outcome:    TokenLookupOutcomeResolved,
+			Field:      field,
+			Transition: transition,
+			Candidates: []string{},
+		}
+	}
+	return fieldLookupNoneResult()
+}
+
+// resolveFieldDirectionMaps returns source/target token-history maps for a
+// requested lookup direction and metadata scope.
+func resolveFieldDirectionMaps(oldMetadata, newMetadata *MetadataEnvelope, direction fieldLookupDirection, scope string) (map[string]*TokenHistory, map[string]*TokenHistory) {
+	switch direction {
+	case fieldLookupDirectionOldToNew:
+		return readHistoryMap(oldMetadata, scope), readHistoryMap(newMetadata, scope)
+	case fieldLookupDirectionNewToOld:
+		return readHistoryMap(newMetadata, scope), readHistoryMap(oldMetadata, scope)
+	default:
+		return nil, nil
+	}
+}
+
+// flattenTokenFields returns flattened field history for one token history node.
+func flattenTokenFields(history *TokenHistory) map[string]*bool {
+	if history == nil {
+		return map[string]*bool{}
+	}
+	return FlattenFieldHistory(history.Fields)
+}
+
+// flattenFieldHistoryNode recursively flattens one FieldHistory subtree into
+// deterministic dot-path keys, using "[*]" for elem traversal.
+func flattenFieldHistoryNode(path string, history *FieldHistory, out map[string]*bool) {
+	if history == nil {
+		return
+	}
+
+	out[path] = cloneBoolPtr(history.MaxItemsOne)
+
+	for _, fieldName := range sortedMapKeys(history.Fields) {
+		flattenFieldHistoryNode(path+"."+fieldName, history.Fields[fieldName], out)
+	}
+	if history.Elem != nil {
+		flattenFieldHistoryNode(path+"[*]", history.Elem, out)
+	}
+}
+
+// fieldLookupNoneResult returns a canonical "none" lookup outcome.
+func fieldLookupNoneResult() FieldLookupResult {
+	return FieldLookupResult{Outcome: TokenLookupOutcomeNone, Candidates: []string{}}
+}
+
+// cloneBoolPtr returns a new pointer copy for value-preserving pointer semantics.
+func cloneBoolPtr(v *bool) *bool {
+	if v == nil {
+		return nil
+	}
+	cloned := *v
+	return &cloned
+}
+
+// sortedMapKeys returns map keys in stable lexical order.
+func sortedMapKeys[V any](m map[string]V) []string {
+	if len(m) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/normalize/field_lookup_test.go
+++ b/internal/normalize/field_lookup_test.go
@@ -1,0 +1,281 @@
+package normalize
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFlattenFieldHistoryDeterministicPaths(t *testing.T) {
+	t.Parallel()
+
+	metadata, err := ParseMetadata(mustReadFieldHistoryFixture(t, filepath.Join("metadata", "parity-vsphere.json")))
+	require.NoError(t, err)
+
+	entry := metadata.AutoAliasing.Resources["vsphere_compute_cluster"]
+	require.NotNil(t, entry)
+
+	flat := FlattenFieldHistory(entry.Fields)
+	require.Equal(t, []string{"host_image", "host_image[*]", "host_image[*].component", "tags"}, collectBoolPaths(flat))
+	require.Equal(t, true, mustBool(t, flat["host_image"]))
+	require.Nil(t, flat["host_image[*]"])
+	require.Equal(t, false, mustBool(t, flat["host_image[*].component"]))
+	require.Equal(t, false, mustBool(t, flat["tags"]))
+}
+
+func TestMaxItemsOneTransitionClassifier(t *testing.T) {
+	t.Parallel()
+
+	trueValue := boolPtr(true)
+	falseValue := boolPtr(false)
+
+	tests := []struct {
+		name string
+		old  *bool
+		new  *bool
+		want MaxItemsOneTransition
+	}{
+		{name: "nil nil", old: nil, new: nil, want: MaxItemsOneTransitionUnknown},
+		{name: "nil true", old: nil, new: trueValue, want: MaxItemsOneTransitionUnknown},
+		{name: "nil false", old: nil, new: falseValue, want: MaxItemsOneTransitionUnknown},
+		{name: "true nil", old: trueValue, new: nil, want: MaxItemsOneTransitionUnknown},
+		{name: "false nil", old: falseValue, new: nil, want: MaxItemsOneTransitionUnknown},
+		{name: "true true", old: trueValue, new: trueValue, want: MaxItemsOneTransitionUnchanged},
+		{name: "false false", old: falseValue, new: falseValue, want: MaxItemsOneTransitionUnchanged},
+		{name: "true false", old: trueValue, new: falseValue, want: MaxItemsOneTransitionChanged},
+		{name: "false true", old: falseValue, new: trueValue, want: MaxItemsOneTransitionChanged},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, ClassifyMaxItemsOneTransition(tt.old, tt.new))
+		})
+	}
+}
+
+func TestResolveFieldSourceSideEvidenceGating(t *testing.T) {
+	t.Parallel()
+
+	oldMetadata := mustParseMetadataJSON(t, `{
+		"auto-aliasing": {
+			"resources": {
+				"pkg_widget": {
+					"current": "pkg:index/widget:Widget",
+					"fields": {
+						"name": {"maxItemsOne": false}
+					}
+				}
+			}
+		}
+	}`)
+	newMetadata := mustParseMetadataJSON(t, `{
+		"auto-aliasing": {
+			"resources": {
+				"pkg_widget": {
+					"current": "pkg:index/widgetV2:Widget",
+					"past": [{"name":"pkg:index/widget:Widget","inCodegen":true,"majorVersion":1}],
+					"fields": {
+						"name": {"maxItemsOne": false},
+						"names": {"maxItemsOne": true}
+					}
+				}
+			}
+		}
+	}`)
+
+	resolved := ResolveField(oldMetadata, newMetadata, scopeResources, "pkg:index/widget:Widget", "name")
+	require.Equal(t, FieldLookupResult{
+		Outcome:    TokenLookupOutcomeResolved,
+		Field:      "name",
+		Transition: MaxItemsOneTransitionUnchanged,
+		Candidates: []string{},
+	}, resolved)
+
+	missingSourceField := ResolveField(oldMetadata, newMetadata, scopeResources, "pkg:index/widget:Widget", "names")
+	require.Equal(t, FieldLookupResult{Outcome: TokenLookupOutcomeNone, Candidates: []string{}}, missingSourceField)
+
+	unknownScope := ResolveField(oldMetadata, newMetadata, "unknown", "pkg:index/widget:Widget", "name")
+	require.Equal(t, FieldLookupResult{Outcome: TokenLookupOutcomeNone, Candidates: []string{}}, unknownScope)
+}
+
+func TestResolveFieldAmbiguousCandidatesDeterministic(t *testing.T) {
+	t.Parallel()
+
+	oldMetadata := mustParseMetadataJSON(t, `{
+		"auto-aliasing": {
+			"resources": {
+				"pkg_widget_a": {
+					"current": "pkg:index/widgetA:WidgetA",
+					"past": [{"name":"pkg:index/legacy:Widget","inCodegen":true,"majorVersion":1}],
+					"fields": {
+						"spec": {"maxItemsOne": true}
+					}
+				},
+				"pkg_widget_b": {
+					"current": "pkg:index/widgetB:WidgetB",
+					"past": [{"name":"pkg:index/legacy:Widget","inCodegen":true,"majorVersion":1}],
+					"fields": {
+						"spec": {"maxItemsOne": true}
+					}
+				}
+			}
+		}
+	}`)
+	newMetadata := mustParseMetadataJSON(t, `{
+		"auto-aliasing": {
+			"resources": {
+				"pkg_widget_a": {
+					"current": "pkg:index/widgetA_v2:WidgetA",
+					"fields": {
+						"spec": {"maxItemsOne": false}
+					}
+				},
+				"pkg_widget_b": {
+					"current": "pkg:index/widgetB_v2:WidgetB",
+					"fields": {
+						"config": {"maxItemsOne": false}
+					}
+				}
+			}
+		}
+	}`)
+
+	result := ResolveField(oldMetadata, newMetadata, scopeResources, "pkg:index/legacy:Widget", "spec")
+	require.Equal(t, TokenLookupOutcomeAmbiguous, result.Outcome)
+	require.Equal(t, []string{"spec"}, result.Candidates)
+
+	result.Candidates[0] = "mutated"
+	again := ResolveField(oldMetadata, newMetadata, scopeResources, "pkg:index/legacy:Widget", "spec")
+	require.Equal(t, TokenLookupOutcomeAmbiguous, again.Outcome)
+	require.Equal(t, []string{"spec"}, again.Candidates)
+}
+
+func TestResolveFieldSingleUnrelatedKnownTargetFieldNoop(t *testing.T) {
+	t.Parallel()
+
+	oldMetadata := mustParseMetadataJSON(t, `{
+		"auto-aliasing": {
+			"resources": {
+				"pkg_widget": {
+					"current": "pkg:index/widget:Widget",
+					"fields": {
+						"spec": {"maxItemsOne": true}
+					}
+				}
+			}
+		}
+	}`)
+	newMetadata := mustParseMetadataJSON(t, `{
+		"auto-aliasing": {
+			"resources": {
+				"pkg_widget": {
+					"current": "pkg:index/widgetV2:Widget",
+					"past": [{"name":"pkg:index/widget:Widget","inCodegen":true,"majorVersion":1}],
+					"fields": {
+						"config": {"maxItemsOne": false}
+					}
+				}
+			}
+		}
+	}`)
+
+	result := ResolveField(oldMetadata, newMetadata, scopeResources, "pkg:index/widget:Widget", "spec")
+	require.Equal(t, FieldLookupResult{Outcome: TokenLookupOutcomeNone, Candidates: []string{}}, result)
+}
+
+func TestResolveNewFieldDirectionalityGating(t *testing.T) {
+	t.Parallel()
+
+	oldMetadata := mustParseMetadataJSON(t, `{
+		"auto-aliasing": {
+			"resources": {
+				"pkg_shared": {
+					"current": "pkg:index/sharedV1:Shared",
+					"fields": {
+						"name": {"maxItemsOne": false}
+					}
+				},
+				"pkg_old_only": {
+					"current": "pkg:index/oldOnly:OldOnly",
+					"fields": {
+						"name": {"maxItemsOne": false}
+					}
+				}
+			}
+		}
+	}`)
+	newMetadata := mustParseMetadataJSON(t, `{
+		"auto-aliasing": {
+			"resources": {
+				"pkg_shared": {
+					"current": "pkg:index/sharedV2:Shared",
+					"past": [{"name":"pkg:index/sharedV1:Shared","inCodegen":true,"majorVersion":1}],
+					"fields": {
+						"name": {"maxItemsOne": false}
+					}
+				},
+				"pkg_new_only": {
+					"current": "pkg:index/newOnly:NewOnly",
+					"fields": {
+						"name": {"maxItemsOne": false}
+					}
+				}
+			}
+		}
+	}`)
+
+	require.Equal(
+		t,
+		FieldLookupResult{Outcome: TokenLookupOutcomeNone, Candidates: []string{}},
+		ResolveField(oldMetadata, newMetadata, scopeResources, "pkg:index/newOnly:NewOnly", "name"),
+	)
+
+	require.Equal(
+		t,
+		FieldLookupResult{Outcome: TokenLookupOutcomeNone, Candidates: []string{}},
+		ResolveNewField(oldMetadata, newMetadata, scopeResources, "pkg:index/oldOnly:OldOnly", "name"),
+	)
+}
+
+func mustReadFieldHistoryFixture(t *testing.T, rel string) []byte {
+	t.Helper()
+
+	data, err := os.ReadFile(filepath.Join("testdata", rel))
+	require.NoError(t, err)
+	return data
+}
+
+func collectBoolPaths(m map[string]*bool) []string {
+	if len(m) == 0 {
+		return nil
+	}
+	paths := make([]string, 0, len(m))
+	for path := range m {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+func boolPtr(v bool) *bool {
+	copy := v
+	return &copy
+}
+
+func mustBool(t *testing.T, v *bool) bool {
+	t.Helper()
+	require.NotNil(t, v)
+	return *v
+}
+
+func mustParseMetadataJSON(t *testing.T, raw string) *MetadataEnvelope {
+	t.Helper()
+	metadata, err := ParseMetadata([]byte(raw))
+	require.NoError(t, err)
+	return metadata
+}

--- a/internal/normalize/resolver.go
+++ b/internal/normalize/resolver.go
@@ -1,0 +1,96 @@
+package normalize
+
+import "strings"
+
+// ResolveEquivalentTypeChange resolves field evidence (old->new) and classifies
+// whether the provided source/target types are maxItems-like equivalents.
+//
+// Example:
+//
+//	result := ResolveEquivalentTypeChange(oldMeta, newMeta, "resources", token, "spec", "array<string>", "string")
+func ResolveEquivalentTypeChange(
+	oldMetadata, newMetadata *MetadataEnvelope,
+	scope, oldToken, oldField, oldType, newType string,
+) EquivalentTypeChangeResult {
+	return resolveEquivalentTypeChange(
+		ResolveField(oldMetadata, newMetadata, scope, oldToken, oldField),
+		oldType,
+		newType,
+	)
+}
+
+// ResolveNewEquivalentTypeChange resolves field evidence (new->old) and classifies
+// whether the provided source/target types are maxItems-like equivalents.
+//
+// Example:
+//
+//	result := ResolveNewEquivalentTypeChange(oldMeta, newMeta, "resources", token, "spec", "string", "array<string>")
+func ResolveNewEquivalentTypeChange(
+	oldMetadata, newMetadata *MetadataEnvelope,
+	scope, newToken, newField, newType, oldType string,
+) EquivalentTypeChangeResult {
+	return resolveEquivalentTypeChange(
+		ResolveNewField(oldMetadata, newMetadata, scope, newToken, newField),
+		newType,
+		oldType,
+	)
+}
+
+// resolveEquivalentTypeChange applies field lookup outcome and transition evidence
+// to compute a conservative equivalence decision for type changes.
+func resolveEquivalentTypeChange(fieldResult FieldLookupResult, sourceType, targetType string) EquivalentTypeChangeResult {
+	result := EquivalentTypeChangeResult{
+		Outcome:    fieldResult.Outcome,
+		Field:      fieldResult.Field,
+		Candidates: append([]string{}, fieldResult.Candidates...),
+	}
+
+	if fieldResult.Outcome != TokenLookupOutcomeResolved {
+		return result
+	}
+
+	if fieldResult.Transition == MaxItemsOneTransitionChanged {
+		result.Equivalent = maxItemsLikeTypeEquivalent(sourceType, targetType)
+	}
+	return result
+}
+
+// maxItemsLikeTypeEquivalent returns true when source/target differ only in
+// array-vs-single cardinality for the same base type.
+func maxItemsLikeTypeEquivalent(sourceType, targetType string) bool {
+	sourceBase, sourceArray, sourceOK := parseTypeCardinality(sourceType)
+	targetBase, targetArray, targetOK := parseTypeCardinality(targetType)
+	if !sourceOK || !targetOK {
+		return false
+	}
+
+	return sourceBase == targetBase && sourceArray != targetArray
+}
+
+// parseTypeCardinality parses normalized type text into a base type and whether
+// it is represented as an array-like form.
+// Supported array forms: `array<T>` and `T[]`.
+func parseTypeCardinality(raw string) (base string, isArray bool, ok bool) {
+	typeName := strings.TrimSpace(raw)
+	if typeName == "" {
+		return "", false, false
+	}
+
+	if strings.HasPrefix(typeName, "array<") && strings.HasSuffix(typeName, ">") {
+		inner := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(typeName, "array<"), ">"))
+		if inner == "" {
+			return "", false, false
+		}
+		return inner, true, true
+	}
+
+	if strings.HasSuffix(typeName, "[]") {
+		inner := strings.TrimSpace(strings.TrimSuffix(typeName, "[]"))
+		if inner == "" {
+			return "", false, false
+		}
+		return inner, true, true
+	}
+
+	return typeName, false, true
+}

--- a/internal/normalize/resolver_test.go
+++ b/internal/normalize/resolver_test.go
@@ -1,0 +1,277 @@
+package normalize
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveEquivalentTypeChangeResolvedEquivalent(t *testing.T) {
+	t.Parallel()
+
+	oldMetadata := mustParseMetadataJSON(t, `{
+		"auto-aliasing": {
+			"resources": {
+				"pkg_widget": {
+					"current": "pkg:index/widget:Widget",
+					"fields": {
+						"list": {"maxItemsOne": true}
+					}
+				}
+			}
+		}
+	}`)
+	newMetadata := mustParseMetadataJSON(t, `{
+		"auto-aliasing": {
+			"resources": {
+				"pkg_widget": {
+					"current": "pkg:index/widgetV2:Widget",
+					"past": [{"name":"pkg:index/widget:Widget","inCodegen":true,"majorVersion":1}],
+					"fields": {
+						"list": {"maxItemsOne": false}
+					}
+				}
+			}
+		}
+	}`)
+
+	result := ResolveEquivalentTypeChange(oldMetadata, newMetadata, scopeResources, "pkg:index/widget:Widget", "list", "array<string>", "string")
+	require.Equal(t, EquivalentTypeChangeResult{Outcome: TokenLookupOutcomeResolved, Equivalent: true, Field: "list", Candidates: []string{}}, result)
+}
+
+func TestResolveEquivalentTypeChangeResolvedButNotEquivalent(t *testing.T) {
+	t.Parallel()
+
+	oldMetadata := mustParseMetadataJSON(t, `{
+		"auto-aliasing": {
+			"resources": {
+				"pkg_widget": {
+					"current": "pkg:index/widget:Widget",
+					"fields": {
+						"list": {"maxItemsOne": true}
+					}
+				}
+			}
+		}
+	}`)
+	newMetadata := mustParseMetadataJSON(t, `{
+		"auto-aliasing": {
+			"resources": {
+				"pkg_widget": {
+					"current": "pkg:index/widgetV2:Widget",
+					"past": [{"name":"pkg:index/widget:Widget","inCodegen":true,"majorVersion":1}],
+					"fields": {
+						"list": {"maxItemsOne": false}
+					}
+				}
+			}
+		}
+	}`)
+
+	result := ResolveEquivalentTypeChange(oldMetadata, newMetadata, scopeResources, "pkg:index/widget:Widget", "list", "array<string>", "number")
+	require.Equal(t, EquivalentTypeChangeResult{Outcome: TokenLookupOutcomeResolved, Equivalent: false, Field: "list", Candidates: []string{}}, result)
+}
+
+func TestResolveEquivalentTypeChangeAmbiguous(t *testing.T) {
+	t.Parallel()
+
+	oldMetadata := mustParseMetadataJSON(t, `{
+		"auto-aliasing": {
+			"resources": {
+				"pkg_widget_a": {
+					"current": "pkg:index/widgetA:WidgetA",
+					"past": [{"name":"pkg:index/legacy:Widget","inCodegen":true,"majorVersion":1}],
+					"fields": {"spec": {"maxItemsOne": true}}
+				},
+				"pkg_widget_b": {
+					"current": "pkg:index/widgetB:WidgetB",
+					"past": [{"name":"pkg:index/legacy:Widget","inCodegen":true,"majorVersion":1}],
+					"fields": {"spec": {"maxItemsOne": true}}
+				}
+			}
+		}
+	}`)
+	newMetadata := mustParseMetadataJSON(t, `{
+		"auto-aliasing": {
+			"resources": {
+				"pkg_widget_a": {
+					"current": "pkg:index/widgetA_v2:WidgetA",
+					"fields": {"spec": {"maxItemsOne": false}}
+				},
+				"pkg_widget_b": {
+					"current": "pkg:index/widgetB_v2:WidgetB",
+					"fields": {"config": {"maxItemsOne": false}}
+				}
+			}
+		}
+	}`)
+
+	result := ResolveEquivalentTypeChange(oldMetadata, newMetadata, scopeResources, "pkg:index/legacy:Widget", "spec", "array<string>", "string")
+	require.Equal(t, TokenLookupOutcomeAmbiguous, result.Outcome)
+	require.False(t, result.Equivalent)
+	require.Equal(t, []string{"spec"}, result.Candidates)
+}
+
+func TestResolveEquivalentTypeChangeNoneNoop(t *testing.T) {
+	t.Parallel()
+
+	oldMetadata := mustParseMetadataJSON(t, `{
+		"auto-aliasing": {
+			"resources": {
+				"pkg_widget": {
+					"current": "pkg:index/widget:Widget",
+					"fields": {
+						"name": {"maxItemsOne": false}
+					}
+				}
+			}
+		}
+	}`)
+	newMetadata := mustParseMetadataJSON(t, `{
+		"auto-aliasing": {
+			"resources": {
+				"pkg_widget": {
+					"current": "pkg:index/widgetV2:Widget",
+					"past": [{"name":"pkg:index/widget:Widget","inCodegen":true,"majorVersion":1}],
+					"fields": {
+						"name": {"maxItemsOne": false}
+					}
+				}
+			}
+		}
+	}`)
+
+	result := ResolveEquivalentTypeChange(oldMetadata, newMetadata, scopeResources, "pkg:index/widget:Widget", "list", "array<string>", "string")
+	require.Equal(t, EquivalentTypeChangeResult{Outcome: TokenLookupOutcomeNone, Equivalent: false, Candidates: []string{}}, result)
+}
+
+func TestResolveNewEquivalentTypeChangeDirectionality(t *testing.T) {
+	t.Parallel()
+
+	oldMetadata := mustParseMetadataJSON(t, `{
+		"auto-aliasing": {
+			"resources": {
+				"pkg_widget": {
+					"current": "pkg:index/widget:Widget",
+					"fields": {
+						"list": {"maxItemsOne": true}
+					}
+				}
+			}
+		}
+	}`)
+	newMetadata := mustParseMetadataJSON(t, `{
+		"auto-aliasing": {
+			"resources": {
+				"pkg_widget": {
+					"current": "pkg:index/widgetV2:Widget",
+					"past": [{"name":"pkg:index/widget:Widget","inCodegen":true,"majorVersion":1}],
+					"fields": {
+						"list": {"maxItemsOne": false}
+					}
+				}
+			}
+		}
+	}`)
+
+	result := ResolveNewEquivalentTypeChange(oldMetadata, newMetadata, scopeResources, "pkg:index/widgetV2:Widget", "list", "string", "array<string>")
+	require.Equal(t, EquivalentTypeChangeResult{Outcome: TokenLookupOutcomeResolved, Equivalent: true, Field: "list", Candidates: []string{}}, result)
+}
+
+func TestResolveEquivalentTypeChangeResolvedUnchangedTransitionNotEquivalent(t *testing.T) {
+	t.Parallel()
+
+	oldMetadata := mustParseMetadataJSON(t, `{
+		"auto-aliasing": {
+			"resources": {
+				"pkg_widget": {
+					"current": "pkg:index/widget:Widget",
+					"fields": {
+						"list": {"maxItemsOne": true}
+					}
+				}
+			}
+		}
+	}`)
+	newMetadata := mustParseMetadataJSON(t, `{
+		"auto-aliasing": {
+			"resources": {
+				"pkg_widget": {
+					"current": "pkg:index/widgetV2:Widget",
+					"past": [{"name":"pkg:index/widget:Widget","inCodegen":true,"majorVersion":1}],
+					"fields": {
+						"list": {"maxItemsOne": true}
+					}
+				}
+			}
+		}
+	}`)
+
+	result := ResolveEquivalentTypeChange(oldMetadata, newMetadata, scopeResources, "pkg:index/widget:Widget", "list", "array<string>", "string")
+	require.Equal(t, EquivalentTypeChangeResult{Outcome: TokenLookupOutcomeResolved, Equivalent: false, Field: "list", Candidates: []string{}}, result)
+}
+
+func TestResolveEquivalentTypeChangeResolvedUnknownTransitionNotEquivalent(t *testing.T) {
+	t.Parallel()
+
+	oldMetadata := mustParseMetadataJSON(t, `{
+		"auto-aliasing": {
+			"resources": {
+				"pkg_widget": {
+					"current": "pkg:index/widget:Widget",
+					"fields": {
+						"list": {}
+					}
+				}
+			}
+		}
+	}`)
+	newMetadata := mustParseMetadataJSON(t, `{
+		"auto-aliasing": {
+			"resources": {
+				"pkg_widget": {
+					"current": "pkg:index/widgetV2:Widget",
+					"past": [{"name":"pkg:index/widget:Widget","inCodegen":true,"majorVersion":1}],
+					"fields": {
+						"list": {"maxItemsOne": false}
+					}
+				}
+			}
+		}
+	}`)
+
+	result := ResolveEquivalentTypeChange(oldMetadata, newMetadata, scopeResources, "pkg:index/widget:Widget", "list", "array<string>", "string")
+	require.Equal(t, EquivalentTypeChangeResult{Outcome: TokenLookupOutcomeResolved, Equivalent: false, Field: "list", Candidates: []string{}}, result)
+}
+
+func TestParseTypeCardinalityEdgeCases(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		raw     string
+		base    string
+		isArray bool
+		ok      bool
+	}{
+		{name: "empty", raw: "", ok: false},
+		{name: "space", raw: "   ", ok: false},
+		{name: "array empty", raw: "array<>", ok: false},
+		{name: "array missing close", raw: "array<string", ok: true, base: "array<string", isArray: false},
+		{name: "array spaced inner", raw: "array< string >", ok: true, base: "string", isArray: true},
+		{name: "slice empty", raw: "[]", ok: false},
+		{name: "slice spaced inner", raw: " string []", ok: true, base: "string", isArray: true},
+		{name: "plain", raw: "number", ok: true, base: "number", isArray: false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			base, isArray, ok := parseTypeCardinality(tt.raw)
+			require.Equal(t, tt.ok, ok)
+			require.Equal(t, tt.base, base)
+			require.Equal(t, tt.isArray, isArray)
+		})
+	}
+}

--- a/internal/normalize/testdata/maxitems/coexistence-edge.json
+++ b/internal/normalize/testdata/maxitems/coexistence-edge.json
@@ -1,0 +1,50 @@
+{
+  "old": {
+    "auto-aliasing": {
+      "resources": {
+        "pkg_widget": {
+          "current": "pkg:index/widget:Widget",
+          "fields": {
+            "filter": {
+              "maxItemsOne": true
+            }
+          }
+        }
+      }
+    }
+  },
+  "new": {
+    "auto-aliasing": {
+      "resources": {
+        "pkg_widget": {
+          "current": "pkg:index/widget:Widget",
+          "fields": {
+            "filter": {
+              "maxItemsOne": true
+            },
+            "filters": {
+              "maxItemsOne": false
+            }
+          }
+        }
+      }
+    }
+  },
+  "expected": {
+    "resources": {
+      "pkg_widget": {
+        "filter": {
+          "old": true,
+          "new": true,
+          "transition": "unchanged"
+        },
+        "filters": {
+          "old": null,
+          "new": false,
+          "transition": "unknown"
+        }
+      }
+    },
+    "datasources": {}
+  }
+}

--- a/internal/normalize/testdata/maxitems/nested-transitions.json
+++ b/internal/normalize/testdata/maxitems/nested-transitions.json
@@ -1,0 +1,103 @@
+{
+  "old": {
+    "auto-aliasing": {
+      "resources": {
+        "pkg_widget": {
+          "current": "pkg:index/widget:Widget",
+          "fields": {
+            "list": {
+              "maxItemsOne": true,
+              "elem": {
+                "fields": {
+                  "child": {
+                    "maxItemsOne": false
+                  }
+                }
+              }
+            },
+            "name": {}
+          }
+        }
+      },
+      "datasources": {
+        "pkg_get_widget": {
+          "current": "pkg:index/getWidget:getWidget",
+          "fields": {
+            "items": {
+              "maxItemsOne": true
+            }
+          }
+        }
+      }
+    }
+  },
+  "new": {
+    "auto-aliasing": {
+      "resources": {
+        "pkg_widget": {
+          "current": "pkg:index/widget:Widget",
+          "fields": {
+            "list": {
+              "maxItemsOne": false,
+              "elem": {
+                "fields": {
+                  "child": {
+                    "maxItemsOne": false
+                  }
+                }
+              }
+            },
+            "name": {
+              "maxItemsOne": false
+            }
+          }
+        }
+      },
+      "datasources": {
+        "pkg_get_widget": {
+          "current": "pkg:index/getWidget:getWidget",
+          "fields": {
+            "items": {
+              "maxItemsOne": true
+            }
+          }
+        }
+      }
+    }
+  },
+  "expected": {
+    "resources": {
+      "pkg_widget": {
+        "list": {
+          "old": true,
+          "new": false,
+          "transition": "changed"
+        },
+        "list[*]": {
+          "old": null,
+          "new": null,
+          "transition": "unknown"
+        },
+        "list[*].child": {
+          "old": false,
+          "new": false,
+          "transition": "unchanged"
+        },
+        "name": {
+          "old": null,
+          "new": false,
+          "transition": "unknown"
+        }
+      }
+    },
+    "datasources": {
+      "pkg_get_widget": {
+        "items": {
+          "old": true,
+          "new": true,
+          "transition": "unchanged"
+        }
+      }
+    }
+  }
+}

--- a/internal/normalize/types.go
+++ b/internal/normalize/types.go
@@ -76,15 +76,15 @@ type FieldHistory struct {
 	Elem        *FieldHistory            `json:"elem,omitempty"`
 }
 
-// TokenLookupOutcome describes token lookup result state.
+// TokenLookupOutcome describes token/field/type lookup result state.
 type TokenLookupOutcome string
 
 const (
 	// TokenLookupOutcomeNone indicates there is no metadata evidence for a resolution.
 	TokenLookupOutcomeNone TokenLookupOutcome = "none"
-	// TokenLookupOutcomeResolved indicates one deterministic token was resolved.
+	// TokenLookupOutcomeResolved indicates one deterministic resolution was found.
 	TokenLookupOutcomeResolved TokenLookupOutcome = "resolved"
-	// TokenLookupOutcomeAmbiguous indicates multiple candidate tokens were found.
+	// TokenLookupOutcomeAmbiguous indicates candidates were not uniquely resolvable.
 	TokenLookupOutcomeAmbiguous TokenLookupOutcome = "ambiguous"
 )
 
@@ -92,6 +92,28 @@ const (
 type TokenLookupResult struct {
 	Outcome TokenLookupOutcome
 	Token   string
+	// Candidates is sorted for deterministic ambiguity handling.
+	Candidates []string
+}
+
+// FieldLookupResult is the result of a field-path lookup request.
+type FieldLookupResult struct {
+	Outcome TokenLookupOutcome
+	Field   string
+	// Transition is set for resolved exact-path matches.
+	Transition MaxItemsOneTransition
+	// Candidates is sorted for deterministic ambiguity handling.
+	Candidates []string
+}
+
+// EquivalentTypeChangeResult reports field lookup classification plus
+// maxItems-like array/single type equivalence.
+type EquivalentTypeChangeResult struct {
+	Outcome TokenLookupOutcome
+	// Equivalent is true only for resolved lookups with array<->single changes
+	// over the same base type.
+	Equivalent bool
+	Field      string
 	// Candidates is sorted for deterministic ambiguity handling.
 	Candidates []string
 }


### PR DESCRIPTION
## Summary
This PR adds field-path and type-equivalence lookup helpers for normalization decisions.

These helpers provide conservative, metadata-backed matching used to classify rename and maxItems-style transitions without schema rewriting.

## What Changed
- Added field history flattening and lookup utilities.
- Added resolver helpers for equivalent type transitions.
- Added targeted fixtures for nested/coexistence maxItems scenarios.
- Added extensive tests for path resolution, ambiguity handling, and equivalence checks.

## Why
Token lookup alone is not enough for field/type transition classification.

Compare-time normalization needs explicit field/type lookup primitives before integration.

## Context
- Builds on token lookup primitives from #107.
- Used by integration work in #110 and #111.

## Testing
- `go test ./internal/normalize -count=1`