### PR TITLE
Fix GoReleaser v2 release job failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 builds:
   - env:
       - CGO_ENABLED=0
@@ -22,4 +24,4 @@ checksum:
 snapshot:
   name_template: "{{ .Tag }}-next"
 changelog:
-  skip: true
+  disable: true


### PR DESCRIPTION
## Summary
- replace deprecated `goreleaser release --rm-dist` with `goreleaser release --clean` in the release workflow
- migrate `.goreleaser.yml` to GoReleaser v2 config (`version: 2`)
- update changelog config from `skip: true` to `disable: true` for v2 compatibility

## Why
The v0.7.0 release workflow failed in the `goreleaser` step with:
- `unknown flag: --rm-dist`

After fixing that flag, v2 config validation also failed until the config migration changes above were applied.

Failing run:
- https://github.com/pulumi/schema-tools/actions/runs/22665204282/job/65695093764

## Validation
- `go run github.com/goreleaser/goreleaser/v2@v2.14.1 release --clean --skip=validate,publish,announce`